### PR TITLE
Web機能のバグ改修(/lispの後にパラメータ無しの場合エラーとする)

### DIFF
--- a/weblisp/src/lib.rs
+++ b/weblisp/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
     use crate::server::run_web_service;
     use crate::server::BIND_ADDRESS;
 
-    const TEST_COUNT: usize = 15;
+    const TEST_COUNT: usize = 16;
 
     fn web_test_client(msg: &str, vec: &mut Vec<String>) -> Result<(), Box<Error>> {
         use std::io::prelude::*;
@@ -264,7 +264,7 @@ mod tests {
     }
     #[test]
     fn test_case_10_405() {
-        let s = vec!["POST /index.html HTTP/1.1"];
+        let s = vec!["PUT /index.html HTTP/1.1"];
 
         let iter = test_skelton(&s);
         let mut iter = iter.iter();
@@ -371,7 +371,26 @@ mod tests {
         assert_str!("Internal Server Error", iter.next());
     }
     #[test]
-    fn test_case_16() {
+    fn test_case_16_lisp_error() {
+        let s = vec!["GET /lisp HTTP/1.1"];
+
+        let iter = test_skelton(&s);
+        let mut iter = iter.iter();
+
+        assert_str!("HTTP/1.1 400 Bad Request", iter.next());
+
+        if let Some(e) = iter.next() {
+            assert_str!("Date: ", Some(&e[0..6].into()))
+        }
+        assert_str!("Server: Rust eLisp", iter.next());
+        assert_str!("Connection: closed", iter.next());
+        assert_str!("Content-type: text/plain", iter.next());
+        iter.next();
+        iter.next();
+        assert_str!("Bad Request", iter.next());
+    }
+    #[test]
+    fn test_case_50() {
         thread::sleep(Duration::from_millis(30));
         thread::spawn(|| {
             if let Err(e) = run_web_service(1024) {
@@ -380,7 +399,7 @@ mod tests {
         });
     }
     #[test]
-    fn test_case_17_stop() {
+    fn test_case_51_stop() {
         let t = thread::spawn(|| {
             let s = vec!["GET /lisp?expr=%28let%20loop%20%28%28i%200%29%29%20%28if%20%28%3C%3D%20100000000%20i%29%20i%20%28loop%20%28%2B%20i%201%29%29%29%29 HTTP/1.1"];
             test_skelton(&s);


### PR DESCRIPTION
Web機能のバグ改修(/lispの後にパラメータ無しの場合エラーとする)