### PR TITLE
独自のassert_strを廃止し、標準のassert_eqに変更する

### DIFF
--- a/elisp/src/lib.rs
+++ b/elisp/src/lib.rs
@@ -35,13 +35,6 @@ fn do_lisp_env(program: &str, env: &lisp::Environment) -> String {
     }
 }
 #[cfg(test)]
-macro_rules! assert_str {
-    ($a: expr,
-     $b: expr) => {
-        assert!($a == $b.to_string())
-    };
-}
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::env;
@@ -51,336 +44,336 @@ mod tests {
 
     #[test]
     fn atom() {
-        assert_str!(do_lisp("10"), "10");
-        assert_str!(do_lisp("10.5"), "10.5");
-        assert_str!(do_lisp("1/2"), "1/2");
-        assert_str!(do_lisp("#t"), "#t");
-        assert_str!(do_lisp("#f"), "#f");
-        assert_str!(do_lisp("#\\a"), "#\\a");
-        assert_str!(do_lisp("\"abc\""), "\"abc\"");
-        assert_str!(do_lisp("#\\space"), "#\\space");
-        assert_str!(do_lisp("#\\tab"), "#\\tab");
-        assert_str!(do_lisp("#\\newline"), "#\\newline");
-        assert_str!(do_lisp("#\\return"), "#\\return");
-        assert_str!(do_lisp("+"), "BuildIn Function");
+        assert_eq!(do_lisp("10"), "10");
+        assert_eq!(do_lisp("10.5"), "10.5");
+        assert_eq!(do_lisp("1/2"), "1/2");
+        assert_eq!(do_lisp("#t"), "#t");
+        assert_eq!(do_lisp("#f"), "#f");
+        assert_eq!(do_lisp("#\\a"), "#\\a");
+        assert_eq!(do_lisp("\"abc\""), "\"abc\"");
+        assert_eq!(do_lisp("#\\space"), "#\\space");
+        assert_eq!(do_lisp("#\\tab"), "#\\tab");
+        assert_eq!(do_lisp("#\\newline"), "#\\newline");
+        assert_eq!(do_lisp("#\\return"), "#\\return");
+        assert_eq!(do_lisp("+"), "BuildIn Function");
     }
     #[test]
     fn atom_utf8() {
-        assert_str!(do_lisp("#\\山"), "#\\山");
-        assert_str!(do_lisp("\"山田太郎\""), "\"山田太郎\"");
-        assert_str!(do_lisp("\"山田(太郎\""), "\"山田(太郎\"");
+        assert_eq!(do_lisp("#\\山"), "#\\山");
+        assert_eq!(do_lisp("\"山田太郎\""), "\"山田太郎\"");
+        assert_eq!(do_lisp("\"山田(太郎\""), "\"山田(太郎\"");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define 山 200)", &env);
-        assert_str!(do_lisp_env("山", &env), "200");
+        assert_eq!(do_lisp_env("山", &env), "200");
     }
     #[test]
     fn plus() {
-        assert_str!(do_lisp("(+ 1 2)"), "3");
-        assert_str!(do_lisp("(+ 1.25 2.25)"), "3.5");
-        assert_str!(do_lisp("(+ 2.5 1)"), "3.5");
-        assert_str!(do_lisp("(+ 3 1.5)"), "4.5");
-        assert_str!(do_lisp("(+ (* 1 2)(* 3 4))"), "14");
-        assert_str!(do_lisp("(+ 1/2 1)"), "3/2");
+        assert_eq!(do_lisp("(+ 1 2)"), "3");
+        assert_eq!(do_lisp("(+ 1.25 2.25)"), "3.5");
+        assert_eq!(do_lisp("(+ 2.5 1)"), "3.5");
+        assert_eq!(do_lisp("(+ 3 1.5)"), "4.5");
+        assert_eq!(do_lisp("(+ (* 1 2)(* 3 4))"), "14");
+        assert_eq!(do_lisp("(+ 1/2 1)"), "3/2");
     }
     #[test]
     fn minus() {
-        assert_str!(do_lisp("(- 6 1)"), "5");
-        assert_str!(do_lisp("(- 5.75 1.5)"), "4.25");
-        assert_str!(do_lisp("(- 6 1.5)"), "4.5");
-        assert_str!(do_lisp("(- 6.5 3)"), "3.5");
-        assert_str!(do_lisp("(- (* 3 4)(* 1 2))"), "10");
-        assert_str!(do_lisp("(- 1 1/2)"), "1/2");
+        assert_eq!(do_lisp("(- 6 1)"), "5");
+        assert_eq!(do_lisp("(- 5.75 1.5)"), "4.25");
+        assert_eq!(do_lisp("(- 6 1.5)"), "4.5");
+        assert_eq!(do_lisp("(- 6.5 3)"), "3.5");
+        assert_eq!(do_lisp("(- (* 3 4)(* 1 2))"), "10");
+        assert_eq!(do_lisp("(- 1 1/2)"), "1/2");
     }
     #[test]
     fn multi() {
-        assert_str!(do_lisp("(* 3 6)"), "18");
-        assert_str!(do_lisp("(* 0.5 5.75)"), "2.875");
-        assert_str!(do_lisp("(* 3.5 6)"), "21");
-        assert_str!(do_lisp("(* 6 3.5)"), "21");
-        assert_str!(do_lisp("(* (+ 3 4)(+ 1 2))"), "21");
-        assert_str!(do_lisp("(* 1/2 1)"), "1/2");
+        assert_eq!(do_lisp("(* 3 6)"), "18");
+        assert_eq!(do_lisp("(* 0.5 5.75)"), "2.875");
+        assert_eq!(do_lisp("(* 3.5 6)"), "21");
+        assert_eq!(do_lisp("(* 6 3.5)"), "21");
+        assert_eq!(do_lisp("(* (+ 3 4)(+ 1 2))"), "21");
+        assert_eq!(do_lisp("(* 1/2 1)"), "1/2");
     }
     #[test]
     fn div() {
-        assert_str!(do_lisp("(/ 4 3)"), "4/3");
-        assert_str!(do_lisp("(/ 1 2)"), "1/2");
-        assert_str!(do_lisp("(/ 9 3)"), "3");
-        assert_str!(do_lisp("(/ 0.75 0.25)"), "3");
-        assert_str!(do_lisp("(/ 9.5 5)"), "1.9");
-        assert_str!(do_lisp("(/ 6 2.5)"), "2.4");
-        assert_str!(do_lisp("(/ 0 0)"), "NaN");
-        assert_str!(do_lisp("(/ 9 0)"), "inf");
-        assert_str!(do_lisp("(/ 10 0.0)"), "inf");
-        assert_str!(do_lisp("(+ 10 (/ 0 0))"), "NaN");
-        assert_str!(do_lisp("(+ 10 (/ 9 0))"), "inf");
-        assert_str!(do_lisp("(/ 0 9)"), "0");
-        assert_str!(do_lisp("(/ 0.0 9)"), "0");
-        assert_str!(do_lisp("(/ (+ 4 4)(+ 2 2))"), "2");
+        assert_eq!(do_lisp("(/ 4 3)"), "4/3");
+        assert_eq!(do_lisp("(/ 1 2)"), "1/2");
+        assert_eq!(do_lisp("(/ 9 3)"), "3");
+        assert_eq!(do_lisp("(/ 0.75 0.25)"), "3");
+        assert_eq!(do_lisp("(/ 9.5 5)"), "1.9");
+        assert_eq!(do_lisp("(/ 6 2.5)"), "2.4");
+        assert_eq!(do_lisp("(/ 0 0)"), "NaN");
+        assert_eq!(do_lisp("(/ 9 0)"), "inf");
+        assert_eq!(do_lisp("(/ 10 0.0)"), "inf");
+        assert_eq!(do_lisp("(+ 10 (/ 0 0))"), "NaN");
+        assert_eq!(do_lisp("(+ 10 (/ 9 0))"), "inf");
+        assert_eq!(do_lisp("(/ 0 9)"), "0");
+        assert_eq!(do_lisp("(/ 0.0 9)"), "0");
+        assert_eq!(do_lisp("(/ (+ 4 4)(+ 2 2))"), "2");
     }
     #[test]
     fn max_f() {
-        assert_str!(do_lisp("(max 10 12 11 1 2)"), "12");
-        assert_str!(do_lisp("(max 10 12 11 1 12)"), "12");
-        assert_str!(do_lisp("(max 10 12 13.5 1 1)"), "13.5");
-        assert_str!(do_lisp("(max 10 123/11 10.5 1 1)"), "123/11");
+        assert_eq!(do_lisp("(max 10 12 11 1 2)"), "12");
+        assert_eq!(do_lisp("(max 10 12 11 1 12)"), "12");
+        assert_eq!(do_lisp("(max 10 12 13.5 1 1)"), "13.5");
+        assert_eq!(do_lisp("(max 10 123/11 10.5 1 1)"), "123/11");
     }
     #[test]
     fn min_f() {
-        assert_str!(do_lisp("(min 10 12 11 3 9)"), "3");
-        assert_str!(do_lisp("(min 3 12 11 3 12)"), "3");
-        assert_str!(do_lisp("(min 10 12 0.5 1 1)"), "0.5");
-        assert_str!(do_lisp("(min 10 1/11 10.5 1 1)"), "1/11");
+        assert_eq!(do_lisp("(min 10 12 11 3 9)"), "3");
+        assert_eq!(do_lisp("(min 3 12 11 3 12)"), "3");
+        assert_eq!(do_lisp("(min 10 12 0.5 1 1)"), "0.5");
+        assert_eq!(do_lisp("(min 10 1/11 10.5 1 1)"), "1/11");
     }
     #[test]
     fn eq() {
-        assert_str!(do_lisp("(= 5 5)"), "#t");
-        assert_str!(do_lisp("(= 5.5 5.5)"), "#t");
-        assert_str!(do_lisp("(= 5 5.0)"), "#t");
-        assert_str!(do_lisp("(= 5.0 5)"), "#t");
-        assert_str!(do_lisp("(= 5 6)"), "#f");
-        assert_str!(do_lisp("(= 5.5 6.6)"), "#f");
-        assert_str!(do_lisp("(= 5 6.6)"), "#f");
-        assert_str!(do_lisp("(= 5.0 6)"), "#f");
-        assert_str!(do_lisp("(= (+ 1 1)(+ 0 2))"), "#t");
+        assert_eq!(do_lisp("(= 5 5)"), "#t");
+        assert_eq!(do_lisp("(= 5.5 5.5)"), "#t");
+        assert_eq!(do_lisp("(= 5 5.0)"), "#t");
+        assert_eq!(do_lisp("(= 5.0 5)"), "#t");
+        assert_eq!(do_lisp("(= 5 6)"), "#f");
+        assert_eq!(do_lisp("(= 5.5 6.6)"), "#f");
+        assert_eq!(do_lisp("(= 5 6.6)"), "#f");
+        assert_eq!(do_lisp("(= 5.0 6)"), "#f");
+        assert_eq!(do_lisp("(= (+ 1 1)(+ 0 2))"), "#t");
     }
     #[test]
     fn than() {
-        assert_str!(do_lisp("(> 6 5)"), "#t");
-        assert_str!(do_lisp("(> 6.5 5.5)"), "#t");
-        assert_str!(do_lisp("(> 6.1 6)"), "#t");
-        assert_str!(do_lisp("(> 6 5.9)"), "#t");
-        assert_str!(do_lisp("(> 6 6)"), "#f");
-        assert_str!(do_lisp("(> 4.5 5.5)"), "#f");
-        assert_str!(do_lisp("(> 4 5.5)"), "#f");
-        assert_str!(do_lisp("(> 4.5 5)"), "#f");
-        assert_str!(do_lisp("(> (+ 3 3) 5)"), "#t");
+        assert_eq!(do_lisp("(> 6 5)"), "#t");
+        assert_eq!(do_lisp("(> 6.5 5.5)"), "#t");
+        assert_eq!(do_lisp("(> 6.1 6)"), "#t");
+        assert_eq!(do_lisp("(> 6 5.9)"), "#t");
+        assert_eq!(do_lisp("(> 6 6)"), "#f");
+        assert_eq!(do_lisp("(> 4.5 5.5)"), "#f");
+        assert_eq!(do_lisp("(> 4 5.5)"), "#f");
+        assert_eq!(do_lisp("(> 4.5 5)"), "#f");
+        assert_eq!(do_lisp("(> (+ 3 3) 5)"), "#t");
     }
     #[test]
     fn less() {
-        assert_str!(do_lisp("(< 5 6)"), "#t");
-        assert_str!(do_lisp("(< 5.6 6.5)"), "#t");
-        assert_str!(do_lisp("(< 5 6.1)"), "#t");
-        assert_str!(do_lisp("(< 5 6.5)"), "#t");
-        assert_str!(do_lisp("(> 6 6)"), "#f");
-        assert_str!(do_lisp("(> 6.5 6.6)"), "#f");
-        assert_str!(do_lisp("(> 6 6.0)"), "#f");
-        assert_str!(do_lisp("(> 5.9 6)"), "#f");
-        assert_str!(do_lisp("(< 5 (+ 3 3))"), "#t");
+        assert_eq!(do_lisp("(< 5 6)"), "#t");
+        assert_eq!(do_lisp("(< 5.6 6.5)"), "#t");
+        assert_eq!(do_lisp("(< 5 6.1)"), "#t");
+        assert_eq!(do_lisp("(< 5 6.5)"), "#t");
+        assert_eq!(do_lisp("(> 6 6)"), "#f");
+        assert_eq!(do_lisp("(> 6.5 6.6)"), "#f");
+        assert_eq!(do_lisp("(> 6 6.0)"), "#f");
+        assert_eq!(do_lisp("(> 5.9 6)"), "#f");
+        assert_eq!(do_lisp("(< 5 (+ 3 3))"), "#t");
     }
     #[test]
     fn than_eq() {
-        assert_str!(do_lisp("(>= 6 6)"), "#t");
-        assert_str!(do_lisp("(>= 6 5)"), "#t");
-        assert_str!(do_lisp("(>= 6.1 5)"), "#t");
-        assert_str!(do_lisp("(>= 7.6 7.6)"), "#t");
-        assert_str!(do_lisp("(>= 6.3 5.2)"), "#t");
-        assert_str!(do_lisp("(>= 6 5.1)"), "#t");
-        assert_str!(do_lisp("(>= 5 6)"), "#f");
-        assert_str!(do_lisp("(>= 5.1 6.2)"), "#f");
-        assert_str!(do_lisp("(>= 5.9 6)"), "#f");
-        assert_str!(do_lisp("(>= 5 6.1)"), "#f");
-        assert_str!(do_lisp("(>= (+ 2 3 1) 6)"), "#t");
+        assert_eq!(do_lisp("(>= 6 6)"), "#t");
+        assert_eq!(do_lisp("(>= 6 5)"), "#t");
+        assert_eq!(do_lisp("(>= 6.1 5)"), "#t");
+        assert_eq!(do_lisp("(>= 7.6 7.6)"), "#t");
+        assert_eq!(do_lisp("(>= 6.3 5.2)"), "#t");
+        assert_eq!(do_lisp("(>= 6 5.1)"), "#t");
+        assert_eq!(do_lisp("(>= 5 6)"), "#f");
+        assert_eq!(do_lisp("(>= 5.1 6.2)"), "#f");
+        assert_eq!(do_lisp("(>= 5.9 6)"), "#f");
+        assert_eq!(do_lisp("(>= 5 6.1)"), "#f");
+        assert_eq!(do_lisp("(>= (+ 2 3 1) 6)"), "#t");
     }
     #[test]
     fn less_eq() {
-        assert_str!(do_lisp("(<= 6 6)"), "#t");
-        assert_str!(do_lisp("(<= 6 5)"), "#f");
-        assert_str!(do_lisp("(<= 6.1 5)"), "#f");
-        assert_str!(do_lisp("(<= 7.6 7.6)"), "#t");
-        assert_str!(do_lisp("(<= 6.3 5.2)"), "#f");
-        assert_str!(do_lisp("(<= 6 5.1)"), "#f");
-        assert_str!(do_lisp("(<= 5 6)"), "#t");
-        assert_str!(do_lisp("(<= 5.1 6.2)"), "#t");
-        assert_str!(do_lisp("(<= 5.9 6)"), "#t");
-        assert_str!(do_lisp("(<= 5 6.1)"), "#t");
-        assert_str!(do_lisp("(<= (+ 3 3) 6)"), "#t");
+        assert_eq!(do_lisp("(<= 6 6)"), "#t");
+        assert_eq!(do_lisp("(<= 6 5)"), "#f");
+        assert_eq!(do_lisp("(<= 6.1 5)"), "#f");
+        assert_eq!(do_lisp("(<= 7.6 7.6)"), "#t");
+        assert_eq!(do_lisp("(<= 6.3 5.2)"), "#f");
+        assert_eq!(do_lisp("(<= 6 5.1)"), "#f");
+        assert_eq!(do_lisp("(<= 5 6)"), "#t");
+        assert_eq!(do_lisp("(<= 5.1 6.2)"), "#t");
+        assert_eq!(do_lisp("(<= 5.9 6)"), "#t");
+        assert_eq!(do_lisp("(<= 5 6.1)"), "#t");
+        assert_eq!(do_lisp("(<= (+ 3 3) 6)"), "#t");
     }
     #[test]
     fn ash() {
-        assert_str!(do_lisp("(ash 10 1)"), "20");
-        assert_str!(do_lisp("(ash 10 -1)"), "5");
-        assert_str!(do_lisp("(ash 10 0)"), "10");
+        assert_eq!(do_lisp("(ash 10 1)"), "20");
+        assert_eq!(do_lisp("(ash 10 -1)"), "5");
+        assert_eq!(do_lisp("(ash 10 0)"), "10");
     }
     #[test]
     fn logand() {
-        assert_str!(do_lisp("(logand 10 2)"), "2");
-        assert_str!(do_lisp("(logand 10 2 3)"), "2");
+        assert_eq!(do_lisp("(logand 10 2)"), "2");
+        assert_eq!(do_lisp("(logand 10 2 3)"), "2");
     }
     #[test]
     fn logior() {
-        assert_str!(do_lisp("(logior 10 2)"), "10");
-        assert_str!(do_lisp("(logior 10 2 3)"), "11");
+        assert_eq!(do_lisp("(logior 10 2)"), "10");
+        assert_eq!(do_lisp("(logior 10 2 3)"), "11");
     }
     #[test]
     fn logxor() {
-        assert_str!(do_lisp("(logxor 10 2)"), "8");
-        assert_str!(do_lisp("(logxor 10 2 2)"), "10");
+        assert_eq!(do_lisp("(logxor 10 2)"), "8");
+        assert_eq!(do_lisp("(logxor 10 2 2)"), "10");
     }
     #[test]
     fn lognot() {
-        assert_str!(do_lisp("(lognot 10)"), "-11");
+        assert_eq!(do_lisp("(lognot 10)"), "-11");
     }
     #[test]
     fn even() {
-        assert_str!(do_lisp("(even? 2)"), "#t");
-        assert_str!(do_lisp("(even? 4)"), "#t");
-        assert_str!(do_lisp("(even? 0)"), "#t");
-        assert_str!(do_lisp("(even? 1)"), "#f");
-        assert_str!(do_lisp("(even? 5)"), "#f");
+        assert_eq!(do_lisp("(even? 2)"), "#t");
+        assert_eq!(do_lisp("(even? 4)"), "#t");
+        assert_eq!(do_lisp("(even? 0)"), "#t");
+        assert_eq!(do_lisp("(even? 1)"), "#f");
+        assert_eq!(do_lisp("(even? 5)"), "#f");
     }
     #[test]
     fn odd() {
-        assert_str!(do_lisp("(odd? 2)"), "#f");
-        assert_str!(do_lisp("(odd? 4)"), "#f");
-        assert_str!(do_lisp("(odd? 0)"), "#f");
-        assert_str!(do_lisp("(odd? 1)"), "#t");
-        assert_str!(do_lisp("(odd? 5)"), "#t");
+        assert_eq!(do_lisp("(odd? 2)"), "#f");
+        assert_eq!(do_lisp("(odd? 4)"), "#f");
+        assert_eq!(do_lisp("(odd? 0)"), "#f");
+        assert_eq!(do_lisp("(odd? 1)"), "#t");
+        assert_eq!(do_lisp("(odd? 5)"), "#t");
     }
     #[test]
     fn zero() {
-        assert_str!(do_lisp("(zero? 0)"), "#t");
-        assert_str!(do_lisp("(zero? 0.0)"), "#t");
-        assert_str!(do_lisp("(zero? 0/3)"), "#t");
-        assert_str!(do_lisp("(zero? 2)"), "#f");
-        assert_str!(do_lisp("(zero? -3)"), "#f");
-        assert_str!(do_lisp("(zero? 2.5)"), "#f");
-        assert_str!(do_lisp("(zero? 1/3)"), "#f");
+        assert_eq!(do_lisp("(zero? 0)"), "#t");
+        assert_eq!(do_lisp("(zero? 0.0)"), "#t");
+        assert_eq!(do_lisp("(zero? 0/3)"), "#t");
+        assert_eq!(do_lisp("(zero? 2)"), "#f");
+        assert_eq!(do_lisp("(zero? -3)"), "#f");
+        assert_eq!(do_lisp("(zero? 2.5)"), "#f");
+        assert_eq!(do_lisp("(zero? 1/3)"), "#f");
     }
     #[test]
     fn positive() {
-        assert_str!(do_lisp("(positive? 0)"), "#f");
-        assert_str!(do_lisp("(positive? 0.0)"), "#f");
-        assert_str!(do_lisp("(positive? 0/3)"), "#f");
-        assert_str!(do_lisp("(positive? 2)"), "#t");
-        assert_str!(do_lisp("(positive? -3)"), "#f");
-        assert_str!(do_lisp("(positive? 2.5)"), "#t");
-        assert_str!(do_lisp("(positive? -1.5)"), "#f");
-        assert_str!(do_lisp("(positive? 1/3)"), "#t");
-        assert_str!(do_lisp("(positive? -1/3)"), "#f");
+        assert_eq!(do_lisp("(positive? 0)"), "#f");
+        assert_eq!(do_lisp("(positive? 0.0)"), "#f");
+        assert_eq!(do_lisp("(positive? 0/3)"), "#f");
+        assert_eq!(do_lisp("(positive? 2)"), "#t");
+        assert_eq!(do_lisp("(positive? -3)"), "#f");
+        assert_eq!(do_lisp("(positive? 2.5)"), "#t");
+        assert_eq!(do_lisp("(positive? -1.5)"), "#f");
+        assert_eq!(do_lisp("(positive? 1/3)"), "#t");
+        assert_eq!(do_lisp("(positive? -1/3)"), "#f");
     }
     #[test]
     fn negative() {
-        assert_str!(do_lisp("(negative? 0)"), "#f");
-        assert_str!(do_lisp("(negative? 0.0)"), "#f");
-        assert_str!(do_lisp("(negative? 0/3)"), "#f");
-        assert_str!(do_lisp("(negative? 2)"), "#f");
-        assert_str!(do_lisp("(negative? -3)"), "#t");
-        assert_str!(do_lisp("(negative? 2.5)"), "#f");
-        assert_str!(do_lisp("(negative? -1.5)"), "#t");
-        assert_str!(do_lisp("(negative? 1/3)"), "#f");
-        assert_str!(do_lisp("(negative? -1/3)"), "#t");
+        assert_eq!(do_lisp("(negative? 0)"), "#f");
+        assert_eq!(do_lisp("(negative? 0.0)"), "#f");
+        assert_eq!(do_lisp("(negative? 0/3)"), "#f");
+        assert_eq!(do_lisp("(negative? 2)"), "#f");
+        assert_eq!(do_lisp("(negative? -3)"), "#t");
+        assert_eq!(do_lisp("(negative? 2.5)"), "#f");
+        assert_eq!(do_lisp("(negative? -1.5)"), "#t");
+        assert_eq!(do_lisp("(negative? 1/3)"), "#f");
+        assert_eq!(do_lisp("(negative? -1/3)"), "#t");
     }
     #[test]
     fn list_f() {
-        assert_str!(do_lisp("(list? (list 1 2 3))"), "#t");
-        assert_str!(do_lisp("(list? 90)"), "#f");
+        assert_eq!(do_lisp("(list? (list 1 2 3))"), "#t");
+        assert_eq!(do_lisp("(list? 90)"), "#f");
     }
     #[test]
     fn pair_f() {
-        assert_str!(do_lisp("(pair? (cons 1 2))"), "#t");
-        assert_str!(do_lisp("(pair? 110)"), "#f");
+        assert_eq!(do_lisp("(pair? (cons 1 2))"), "#t");
+        assert_eq!(do_lisp("(pair? 110)"), "#f");
     }
     #[test]
     fn char_f() {
-        assert_str!(do_lisp("(char? #\\a)"), "#t");
-        assert_str!(do_lisp("(char? 100)"), "#f");
+        assert_eq!(do_lisp("(char? #\\a)"), "#t");
+        assert_eq!(do_lisp("(char? 100)"), "#f");
     }
     #[test]
     fn string_f() {
-        assert_str!(do_lisp("(string? \"a\")"), "#t");
-        assert_str!(do_lisp("(string? 100)"), "#f");
+        assert_eq!(do_lisp("(string? \"a\")"), "#t");
+        assert_eq!(do_lisp("(string? 100)"), "#f");
     }
     #[test]
     fn integer_f() {
-        assert_str!(do_lisp("(integer? 10)"), "#t");
-        assert_str!(do_lisp("(integer? \"a\")"), "#f");
+        assert_eq!(do_lisp("(integer? 10)"), "#t");
+        assert_eq!(do_lisp("(integer? \"a\")"), "#f");
     }
     #[test]
     fn number_f() {
-        assert_str!(do_lisp("(number? 10)"), "#t");
-        assert_str!(do_lisp("(number? 10.5)"), "#t");
-        assert_str!(do_lisp("(number? 1/3)"), "#t");
-        assert_str!(do_lisp("(number? \"a\")"), "#f");
+        assert_eq!(do_lisp("(number? 10)"), "#t");
+        assert_eq!(do_lisp("(number? 10.5)"), "#t");
+        assert_eq!(do_lisp("(number? 1/3)"), "#t");
+        assert_eq!(do_lisp("(number? \"a\")"), "#f");
     }
     #[test]
     fn procedure_f() {
-        assert_str!(do_lisp("(procedure? (lambda (n)n))"), "#t");
-        assert_str!(do_lisp("(procedure? +)"), "#t");
-        assert_str!(do_lisp("(procedure? 10)"), "#f");
+        assert_eq!(do_lisp("(procedure? (lambda (n)n))"), "#t");
+        assert_eq!(do_lisp("(procedure? +)"), "#t");
+        assert_eq!(do_lisp("(procedure? 10)"), "#f");
     }
     #[test]
     fn define() {
         let env = lisp::Environment::new();
         do_lisp_env("(define a 100)", &env);
-        assert_str!(do_lisp_env("a", &env), "100");
+        assert_eq!(do_lisp_env("a", &env), "100");
         do_lisp_env("(define a 10.5)", &env);
-        assert_str!(do_lisp_env("a", &env), "10.5");
+        assert_eq!(do_lisp_env("a", &env), "10.5");
         do_lisp_env("(define a #t)", &env);
-        assert_str!(do_lisp_env("a", &env), "#t");
+        assert_eq!(do_lisp_env("a", &env), "#t");
         do_lisp_env("(define a #\\A)", &env);
-        assert_str!(do_lisp_env("a", &env), "#\\A");
+        assert_eq!(do_lisp_env("a", &env), "#\\A");
 
         do_lisp_env("(define (fuga a b)(* a b))", &env);
-        assert_str!(do_lisp_env("(fuga 6 8)", &env), "48");
+        assert_eq!(do_lisp_env("(fuga 6 8)", &env), "48");
         do_lisp_env("(define (hoge a b) a)", &env);
-        assert_str!(do_lisp_env("(hoge 6 8)", &env), "6");
+        assert_eq!(do_lisp_env("(hoge 6 8)", &env), "6");
 
         do_lisp_env("(define a 100)", &env);
         do_lisp_env("(define b a)", &env);
-        assert_str!(do_lisp_env("b", &env), "100");
+        assert_eq!(do_lisp_env("b", &env), "100");
 
         do_lisp_env("(define plus +)", &env);
-        assert_str!(do_lisp_env("(plus 10 20)", &env), "30");
+        assert_eq!(do_lisp_env("(plus 10 20)", &env), "30");
 
         do_lisp_env("(define (p-nashi)(* 10 20))", &env);
-        assert_str!(do_lisp_env("(p-nashi)", &env), "200");
+        assert_eq!(do_lisp_env("(p-nashi)", &env), "200");
 
         do_lisp_env("(define (hoge a b)(define (alpha x)(+ x 10))(define (beta y)(+ y 10))(+ (alpha a)(beta b)))",&env);
-        assert_str!(do_lisp_env("(hoge 1 2)", &env), "23");
-        assert_str!(do_lisp_env("(hoge 3 4)", &env), "27");
+        assert_eq!(do_lisp_env("(hoge 1 2)", &env), "23");
+        assert_eq!(do_lisp_env("(hoge 3 4)", &env), "27");
     }
     #[test]
     fn lambda() {
-        assert_str!(do_lisp("((lambda (a b)(+ a b)) 1 2)"), "3");
+        assert_eq!(do_lisp("((lambda (a b)(+ a b)) 1 2)"), "3");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define hoge (lambda (a b) (+ a b)))", &env);
-        assert_str!(do_lisp_env("(hoge 6 8)", &env), "14");
+        assert_eq!(do_lisp_env("(hoge 6 8)", &env), "14");
         do_lisp_env("(define hoge (lambda (a b) b))", &env);
-        assert_str!(do_lisp_env("(hoge 6 8)", &env), "8");
+        assert_eq!(do_lisp_env("(hoge 6 8)", &env), "8");
     }
     #[test]
     fn if_f() {
-        assert_str!(do_lisp("(if (= 10 10) #\\a)"), "#\\a");
-        assert_str!(do_lisp("(if (= 10 11) #\\a)"), "nil");
-        assert_str!(do_lisp("(if (<= 1 6) #\\a #\\b)"), "#\\a");
-        assert_str!(do_lisp("(if (<= 9 6) #\\a #\\b)"), "#\\b");
+        assert_eq!(do_lisp("(if (= 10 10) #\\a)"), "#\\a");
+        assert_eq!(do_lisp("(if (= 10 11) #\\a)"), "nil");
+        assert_eq!(do_lisp("(if (<= 1 6) #\\a #\\b)"), "#\\a");
+        assert_eq!(do_lisp("(if (<= 9 6) #\\a #\\b)"), "#\\b");
     }
     #[test]
     fn cond() {
-        assert_str!(do_lisp("(cond ((= 10 10)))"), "#t");
-        assert_str!(do_lisp("(cond ((= 100 10)))"), "nil");
-        assert_str!(do_lisp("(cond (else 10))"), "10");
+        assert_eq!(do_lisp("(cond ((= 10 10)))"), "#t");
+        assert_eq!(do_lisp("(cond ((= 100 10)))"), "nil");
+        assert_eq!(do_lisp("(cond (else 10))"), "10");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 10)", &env);
-        assert_str!(do_lisp_env("(cond (a 20))", &env), "20");
-        assert_str!(
+        assert_eq!(do_lisp_env("(cond (a 20))", &env), "20");
+        assert_eq!(
             do_lisp_env("(cond ((= a 10) \"A\")((= a 20) \"B\")(else \"C\"))", &env),
             "\"A\""
         );
         do_lisp_env("(define a 20)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(cond ((= a 10) \"A\")((= a 20) \"B\")(else \"C\"))", &env),
             "\"B\""
         );
         do_lisp_env("(define a 30)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(cond ((= a 10) \"A\")((= a 20) \"B\")(else \"C\"))", &env),
             "\"C\""
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(cond ((= a 10) \"A\")((= a 20) \"B\")(else (* a 10)))",
                 &env
@@ -388,62 +381,62 @@ mod tests {
             "300"
         );
         do_lisp_env("(define a 100)", &env);
-        assert_str!(do_lisp_env("(cond ((= a 10) 20)(else 30 40))", &env), "40");
-        assert_str!(
+        assert_eq!(do_lisp_env("(cond ((= a 10) 20)(else 30 40))", &env), "40");
+        assert_eq!(
             do_lisp_env("(cond ((= a 100) 20 30)(else 40 50))", &env),
             "30"
         );
     }
     #[test]
     fn eqv() {
-        assert_str!(do_lisp("(eqv? 1.1 1.1)"), "#t");
-        assert_str!(do_lisp("(eq? 1.1 1.1)"), "#t");
-        assert_str!(do_lisp("(eqv? 1.1 1.2)"), "#f");
-        assert_str!(do_lisp("(eqv? 10 (+ 2 8))"), "#t");
-        assert_str!(do_lisp("(eqv? 1 2)"), "#f");
-        assert_str!(do_lisp("(eqv? 5/3 5/3)"), "#t");
-        assert_str!(do_lisp("(eqv? 5/3 4/3)"), "#f");
-        assert_str!(do_lisp("(eqv? (+ 1 2) 9/3)"), "#t");
-        assert_str!(do_lisp("(eqv? 8/2 (+ 1 3))"), "#t");
-        assert_str!(do_lisp("(eqv? 1 1.0)"), "#f");
-        assert_str!(do_lisp("(eqv? 1/1 1.0)"), "#f");
-        assert_str!(do_lisp("(eqv? 1.0 1)"), "#f");
+        assert_eq!(do_lisp("(eqv? 1.1 1.1)"), "#t");
+        assert_eq!(do_lisp("(eq? 1.1 1.1)"), "#t");
+        assert_eq!(do_lisp("(eqv? 1.1 1.2)"), "#f");
+        assert_eq!(do_lisp("(eqv? 10 (+ 2 8))"), "#t");
+        assert_eq!(do_lisp("(eqv? 1 2)"), "#f");
+        assert_eq!(do_lisp("(eqv? 5/3 5/3)"), "#t");
+        assert_eq!(do_lisp("(eqv? 5/3 4/3)"), "#f");
+        assert_eq!(do_lisp("(eqv? (+ 1 2) 9/3)"), "#t");
+        assert_eq!(do_lisp("(eqv? 8/2 (+ 1 3))"), "#t");
+        assert_eq!(do_lisp("(eqv? 1 1.0)"), "#f");
+        assert_eq!(do_lisp("(eqv? 1/1 1.0)"), "#f");
+        assert_eq!(do_lisp("(eqv? 1.0 1)"), "#f");
 
-        assert_str!(do_lisp("(eq? 'a 'a)"), "#t");
-        assert_str!(do_lisp("(eq? 'a 'b)"), "#f");
-        assert_str!(do_lisp("(eq? 'a 10)"), "#f");
-        assert_str!(do_lisp("(eq? #f #f)"), "#t");
-        assert_str!(do_lisp("(eq? #t #f)"), "#f");
-        assert_str!(do_lisp("(eq? #t 10)"), "#f");
-        assert_str!(do_lisp("(eq? #\\a #\\a)"), "#t");
-        assert_str!(do_lisp("(eq? #\\a #\\b)"), "#f");
-        assert_str!(do_lisp("(eq? #\\space #\\space)"), "#t");
+        assert_eq!(do_lisp("(eq? 'a 'a)"), "#t");
+        assert_eq!(do_lisp("(eq? 'a 'b)"), "#f");
+        assert_eq!(do_lisp("(eq? 'a 10)"), "#f");
+        assert_eq!(do_lisp("(eq? #f #f)"), "#t");
+        assert_eq!(do_lisp("(eq? #t #f)"), "#f");
+        assert_eq!(do_lisp("(eq? #t 10)"), "#f");
+        assert_eq!(do_lisp("(eq? #\\a #\\a)"), "#t");
+        assert_eq!(do_lisp("(eq? #\\a #\\b)"), "#f");
+        assert_eq!(do_lisp("(eq? #\\space #\\space)"), "#t");
     }
     #[test]
     fn case() {
-        assert_str!(do_lisp("(case 10)"), "nil");
-        assert_str!(do_lisp("(case 10 ((1 2) \"A\"))"), "nil");
-        assert_str!(do_lisp("(case 10 (else 20))"), "20");
-        assert_str!(do_lisp("(case 10 (else))"), "nil");
+        assert_eq!(do_lisp("(case 10)"), "nil");
+        assert_eq!(do_lisp("(case 10 ((1 2) \"A\"))"), "nil");
+        assert_eq!(do_lisp("(case 10 (else 20))"), "20");
+        assert_eq!(do_lisp("(case 10 (else))"), "nil");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 100)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(case a ((100 200) \"A\")(else \"B\"))", &env),
             "\"A\""
         );
         do_lisp_env("(define a 1)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(case a ((100 200) \"A\")(else \"B\"))", &env),
             "\"B\""
         );
         do_lisp_env("(define a 200)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(case a ((100 200) \"A\")(else \"B\"))", &env),
             "\"A\""
         );
         do_lisp_env("(define a 400)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(case a ((100 200) \"A\")((300 400) \"B\")(else \"C\"))",
                 &env
@@ -451,7 +444,7 @@ mod tests {
             "\"B\""
         );
         do_lisp_env("(define b 100)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(case a ((200 b) \"A\")((300 400) \"B\")(else \"C\"))",
                 &env
@@ -459,7 +452,7 @@ mod tests {
             "\"B\""
         );
         do_lisp_env("(define a 100)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(case a ((200 b) \"A\")((300 400) \"B\")(else \"C\"))",
                 &env
@@ -467,7 +460,7 @@ mod tests {
             "\"A\""
         );
         do_lisp_env("(define a 1000)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(case a ((b 200) \"A\")((300 400) \"B\")(else \"C\"))",
                 &env
@@ -475,81 +468,81 @@ mod tests {
             "\"C\""
         );
         do_lisp_env("(define a 100) ", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(case a ((100 200) \"A\" \"B\") (else \"C\"))", &env),
             "\"B\""
         );
     }
     #[test]
     fn apply() {
-        assert_str!(do_lisp("(apply + (list 1 2 3))"), "6");
-        assert_str!(do_lisp("(apply + (list (+ 1 1) 2 3))"), "7");
-        assert_str!(do_lisp("(apply - (list 5 3 2))"), "0");
-        assert_str!(do_lisp("(apply (lambda (a b) (+ a b)) (list 1 2))"), "3");
-        assert_str!(do_lisp("(apply + (iota 10))"), "45");
+        assert_eq!(do_lisp("(apply + (list 1 2 3))"), "6");
+        assert_eq!(do_lisp("(apply + (list (+ 1 1) 2 3))"), "7");
+        assert_eq!(do_lisp("(apply - (list 5 3 2))"), "0");
+        assert_eq!(do_lisp("(apply (lambda (a b) (+ a b)) (list 1 2))"), "3");
+        assert_eq!(do_lisp("(apply + (iota 10))"), "45");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define (hoge x y)(* x y))", &env);
-        assert_str!(do_lisp_env("(apply hoge (list 3 4))", &env), "12");
+        assert_eq!(do_lisp_env("(apply hoge (list 3 4))", &env), "12");
     }
     #[test]
     fn identity() {
-        assert_str!(do_lisp("(identity (+ 1 2 3))"), "6");
-        assert_str!(do_lisp("(identity ((lambda (a b) (+ a b)) 1 2))"), "3");
+        assert_eq!(do_lisp("(identity (+ 1 2 3))"), "6");
+        assert_eq!(do_lisp("(identity ((lambda (a b) (+ a b)) 1 2))"), "3");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 100)", &env);
-        assert_str!(do_lisp_env("(identity a)", &env), "100");
+        assert_eq!(do_lisp_env("(identity a)", &env), "100");
     }
     #[test]
     fn modulo() {
-        assert_str!(do_lisp("(modulo 11 3)"), "2");
-        assert_str!(do_lisp("(modulo 11 (+ 1 2))"), "2");
-        assert_str!(do_lisp("(modulo  3 5)"), "3");
+        assert_eq!(do_lisp("(modulo 11 3)"), "2");
+        assert_eq!(do_lisp("(modulo 11 (+ 1 2))"), "2");
+        assert_eq!(do_lisp("(modulo  3 5)"), "3");
     }
     #[test]
     fn quotient() {
-        assert_str!(do_lisp("(quotient 11 3)"), "3");
-        assert_str!(do_lisp("(quotient 11 (+ 1 2))"), "3");
-        assert_str!(do_lisp("(quotient 3 5)"), "0");
+        assert_eq!(do_lisp("(quotient 11 3)"), "3");
+        assert_eq!(do_lisp("(quotient 11 (+ 1 2))"), "3");
+        assert_eq!(do_lisp("(quotient 3 5)"), "0");
     }
     #[test]
     fn expt() {
-        assert_str!(do_lisp("(expt 2 3)"), "8");
-        assert_str!(do_lisp("(expt 2 (+ 1 2))"), "8");
-        assert_str!(do_lisp("(expt 2 -2)"), "1/4");
-        assert_str!(do_lisp("(expt 2 0)"), "1");
-        assert_str!(do_lisp("(expt 2.0 3.0)"), "8");
-        assert_str!(do_lisp("(expt 2.0 3)"), "8");
-        assert_str!(do_lisp("(expt 2 3.0)"), "8");
+        assert_eq!(do_lisp("(expt 2 3)"), "8");
+        assert_eq!(do_lisp("(expt 2 (+ 1 2))"), "8");
+        assert_eq!(do_lisp("(expt 2 -2)"), "1/4");
+        assert_eq!(do_lisp("(expt 2 0)"), "1");
+        assert_eq!(do_lisp("(expt 2.0 3.0)"), "8");
+        assert_eq!(do_lisp("(expt 2.0 3)"), "8");
+        assert_eq!(do_lisp("(expt 2 3.0)"), "8");
     }
     #[test]
     fn and() {
-        assert_str!(do_lisp("(and (= 1 1)(= 2 2))"), "#t");
-        assert_str!(do_lisp("(and (= 1 1)(= 2 3))"), "#f");
-        assert_str!(do_lisp("(and (= 2 1)(= 2 2))"), "#f");
-        assert_str!(do_lisp("(and (= 0 1)(= 2 3))"), "#f");
+        assert_eq!(do_lisp("(and (= 1 1)(= 2 2))"), "#t");
+        assert_eq!(do_lisp("(and (= 1 1)(= 2 3))"), "#f");
+        assert_eq!(do_lisp("(and (= 2 1)(= 2 2))"), "#f");
+        assert_eq!(do_lisp("(and (= 0 1)(= 2 3))"), "#f");
     }
     #[test]
     fn or() {
-        assert_str!(do_lisp("(or (= 1 1)(= 2 2))"), "#t");
-        assert_str!(do_lisp("(or (= 1 1)(= 2 3))"), "#t");
-        assert_str!(do_lisp("(or (= 2 1)(= 2 2))"), "#t");
-        assert_str!(do_lisp("(or (= 0 1)(= 2 3))"), "#f");
+        assert_eq!(do_lisp("(or (= 1 1)(= 2 2))"), "#t");
+        assert_eq!(do_lisp("(or (= 1 1)(= 2 3))"), "#t");
+        assert_eq!(do_lisp("(or (= 2 1)(= 2 2))"), "#t");
+        assert_eq!(do_lisp("(or (= 0 1)(= 2 3))"), "#f");
     }
     #[test]
     fn not() {
-        assert_str!(do_lisp("(not (= 1 1))"), "#f");
-        assert_str!(do_lisp("(not (= 2 1))"), "#t");
+        assert_eq!(do_lisp("(not (= 1 1))"), "#f");
+        assert_eq!(do_lisp("(not (= 2 1))"), "#t");
     }
     #[test]
     fn let_f() {
-        assert_str!(do_lisp("(let ((a 10)(b 20)) (+ a b))"), "30");
-        assert_str!(
+        assert_eq!(do_lisp("(let ((a 10)(b 20)) (+ a b))"), "30");
+        assert_eq!(
             do_lisp("(let loop ((i 0)(j 0)) (if (<= 10 i) (+ i j) (loop (+ i 1)(+ j 2))))"),
             "30"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(let loop ((i 0)) (if (<= 10 i) i (+ 10 (loop (+ i 1)))))"),
             "110"
         );
@@ -557,7 +550,7 @@ mod tests {
     #[test]
     fn tail_recurcieve_1() {
         // stack overflow check
-        assert_str!(
+        assert_eq!(
             do_lisp("(let loop ((i 0)) (if (<= 10000 i) i (loop (+ i 1))))"),
             "10000"
         );
@@ -565,7 +558,7 @@ mod tests {
     #[test]
     fn tail_recurcieve_2() {
         // stack overflow check
-        assert_str!(
+        assert_eq!(
             do_lisp("(let loop ((i 0)) (cond ((<= 10000 i) i) (else (loop (+ i 1)))))"),
             "10000"
         );
@@ -575,177 +568,177 @@ mod tests {
         // stack overflow check
         let env = lisp::Environment::new();
         do_lisp_env("(define (hoge i) (if (<= 10000 i) i (hoge (+ i 1))))", &env);
-        assert_str!(do_lisp_env("(hoge 0)", &env), "10000");
+        assert_eq!(do_lisp_env("(hoge 0)", &env), "10000");
     }
     #[test]
     fn time_f() {
         let env = lisp::Environment::new();
-        assert_str!(do_lisp_env("(time (+ 10 20))", &env), "30");
+        assert_eq!(do_lisp_env("(time (+ 10 20))", &env), "30");
     }
     #[test]
     fn set_f() {
         let env = lisp::Environment::new();
         do_lisp_env("(define c 0)", &env);
         do_lisp_env("(set! c 10)", &env);
-        assert_str!(do_lisp_env("c", &env), "10");
+        assert_eq!(do_lisp_env("c", &env), "10");
         do_lisp_env("(set! c (+ c 1))", &env);
-        assert_str!(do_lisp_env("c", &env), "11");
+        assert_eq!(do_lisp_env("c", &env), "11");
     }
     #[test]
     fn list() {
-        assert_str!(do_lisp("(list 1 2)"), "(1 2)");
-        assert_str!(do_lisp("(list 0.5 1)"), "(0.5 1)");
-        assert_str!(do_lisp("(list #t #f)"), "(#t #f)");
-        assert_str!(do_lisp("(list (list 1)(list 2))"), "((1)(2))");
-        assert_str!(
+        assert_eq!(do_lisp("(list 1 2)"), "(1 2)");
+        assert_eq!(do_lisp("(list 0.5 1)"), "(0.5 1)");
+        assert_eq!(do_lisp("(list #t #f)"), "(#t #f)");
+        assert_eq!(do_lisp("(list (list 1)(list 2))"), "((1)(2))");
+        assert_eq!(
             do_lisp("(list (list (list 1))(list 2)(list 3))"),
             "(((1))(2)(3))"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a 10)", &env);
         do_lisp_env("(define b 20)", &env);
-        assert_str!(do_lisp_env("(list a b)", &env), "(10 20)");
+        assert_eq!(do_lisp_env("(list a b)", &env), "(10 20)");
     }
     #[test]
     fn make_list() {
-        assert_str!(do_lisp("(make-list 10 0)"), "(0 0 0 0 0 0 0 0 0 0)");
-        assert_str!(
+        assert_eq!(do_lisp("(make-list 10 0)"), "(0 0 0 0 0 0 0 0 0 0)");
+        assert_eq!(
             do_lisp("(make-list 4 (list 1 2 3))"),
             "((1 2 3)(1 2 3)(1 2 3)(1 2 3))"
         );
-        assert_str!(do_lisp("(make-list 8 'a)"), "(a a a a a a a a)");
+        assert_eq!(do_lisp("(make-list 8 'a)"), "(a a a a a a a a)");
     }
     #[test]
     fn null_f() {
-        assert_str!(do_lisp("(null? (list))"), "#t");
-        assert_str!(do_lisp("(null? (list 10))"), "#f");
-        assert_str!(do_lisp("(null? 10)"), "#f");
+        assert_eq!(do_lisp("(null? (list))"), "#t");
+        assert_eq!(do_lisp("(null? (list 10))"), "#f");
+        assert_eq!(do_lisp("(null? 10)"), "#f");
     }
     #[test]
     fn length() {
-        assert_str!(do_lisp("(length (list))"), "0");
-        assert_str!(do_lisp("(length (list 3))"), "1");
-        assert_str!(do_lisp("(length (iota 10))"), "10");
+        assert_eq!(do_lisp("(length (list))"), "0");
+        assert_eq!(do_lisp("(length (list 3))"), "1");
+        assert_eq!(do_lisp("(length (iota 10))"), "10");
     }
     #[test]
     fn car() {
-        assert_str!(do_lisp("(car (list 1))"), "1");
-        assert_str!(do_lisp("(car (list (list 2)))"), "(2)");
-        assert_str!(
+        assert_eq!(do_lisp("(car (list 1))"), "1");
+        assert_eq!(do_lisp("(car (list (list 2)))"), "(2)");
+        assert_eq!(
             do_lisp("(car (list (list (list 1))(list 2)(list 3)))"),
             "((1))"
         );
-        assert_str!(do_lisp("(car (cons 10 20))"), "10");
+        assert_eq!(do_lisp("(car (cons 10 20))"), "10");
     }
     #[test]
     fn cdr() {
-        assert_str!(do_lisp("(cdr (list 1 2))"), "(2)");
-        assert_str!(do_lisp("(cdr (list 1 0.5))"), "(0.5)");
-        assert_str!(do_lisp("(cdr (list 1 (list 3)))"), "((3))");
-        assert_str!(do_lisp("(cdr (cons 1 2))"), "2");
-        assert_str!(do_lisp("(cdr (list 1))"), "()");
+        assert_eq!(do_lisp("(cdr (list 1 2))"), "(2)");
+        assert_eq!(do_lisp("(cdr (list 1 0.5))"), "(0.5)");
+        assert_eq!(do_lisp("(cdr (list 1 (list 3)))"), "((3))");
+        assert_eq!(do_lisp("(cdr (cons 1 2))"), "2");
+        assert_eq!(do_lisp("(cdr (list 1))"), "()");
     }
     #[test]
     fn cadr() {
-        assert_str!(do_lisp("(cadr (list 1 2))"), "2");
-        assert_str!(do_lisp("(cadr (list 1 2 3))"), "2");
+        assert_eq!(do_lisp("(cadr (list 1 2))"), "2");
+        assert_eq!(do_lisp("(cadr (list 1 2 3))"), "2");
     }
     #[test]
     fn cons() {
-        assert_str!(do_lisp("(cons  1 2)"), "(1 . 2)");
-        assert_str!(do_lisp("(cons 1.5 2.5)"), "(1.5 . 2.5)");
-        assert_str!(do_lisp("(cons  1 1.5)"), "(1 . 1.5)");
-        assert_str!(do_lisp("(cons 1 (list 2))"), "(1 2)");
-        assert_str!(do_lisp("(cons (list 1)(list 2))"), "((1) 2)");
+        assert_eq!(do_lisp("(cons  1 2)"), "(1 . 2)");
+        assert_eq!(do_lisp("(cons 1.5 2.5)"), "(1.5 . 2.5)");
+        assert_eq!(do_lisp("(cons  1 1.5)"), "(1 . 1.5)");
+        assert_eq!(do_lisp("(cons 1 (list 2))"), "(1 2)");
+        assert_eq!(do_lisp("(cons (list 1)(list 2))"), "((1) 2)");
     }
     #[test]
     fn append() {
-        assert_str!(do_lisp("(append (list 1)(list 2))"), "(1 2)");
-        assert_str!(do_lisp("(append (list 1)(list 2)(list 3))"), "(1 2 3)");
-        assert_str!(
+        assert_eq!(do_lisp("(append (list 1)(list 2))"), "(1 2)");
+        assert_eq!(do_lisp("(append (list 1)(list 2)(list 3))"), "(1 2 3)");
+        assert_eq!(
             do_lisp("(append (list (list 10))(list 2)(list 3))"),
             "((10) 2 3)"
         );
-        assert_str!(do_lisp("(append (iota 5) (list 100))"), "(0 1 2 3 4 100)");
+        assert_eq!(do_lisp("(append (iota 5) (list 100))"), "(0 1 2 3 4 100)");
     }
     #[test]
     fn take() {
-        assert_str!(do_lisp("(take (iota 10) 0)"), "()");
-        assert_str!(do_lisp("(take (iota 10) 1)"), "(0)");
-        assert_str!(do_lisp("(take (iota 10) 3)"), "(0 1 2)");
-        assert_str!(do_lisp("(take (iota 10) 9)"), "(0 1 2 3 4 5 6 7 8)");
-        assert_str!(do_lisp("(take (iota 10) 10)"), "(0 1 2 3 4 5 6 7 8 9)");
+        assert_eq!(do_lisp("(take (iota 10) 0)"), "()");
+        assert_eq!(do_lisp("(take (iota 10) 1)"), "(0)");
+        assert_eq!(do_lisp("(take (iota 10) 3)"), "(0 1 2)");
+        assert_eq!(do_lisp("(take (iota 10) 9)"), "(0 1 2 3 4 5 6 7 8)");
+        assert_eq!(do_lisp("(take (iota 10) 10)"), "(0 1 2 3 4 5 6 7 8 9)");
     }
     #[test]
     fn drop() {
-        assert_str!(do_lisp("(drop (iota 10) 0)"), "(0 1 2 3 4 5 6 7 8 9)");
-        assert_str!(do_lisp("(drop (iota 10) 1)"), "(1 2 3 4 5 6 7 8 9)");
-        assert_str!(do_lisp("(drop (iota 10) 3)"), "(3 4 5 6 7 8 9)");
-        assert_str!(do_lisp("(drop (iota 10) 9)"), "(9)");
-        assert_str!(do_lisp("(drop (iota 10) 10)"), "()");
+        assert_eq!(do_lisp("(drop (iota 10) 0)"), "(0 1 2 3 4 5 6 7 8 9)");
+        assert_eq!(do_lisp("(drop (iota 10) 1)"), "(1 2 3 4 5 6 7 8 9)");
+        assert_eq!(do_lisp("(drop (iota 10) 3)"), "(3 4 5 6 7 8 9)");
+        assert_eq!(do_lisp("(drop (iota 10) 9)"), "(9)");
+        assert_eq!(do_lisp("(drop (iota 10) 10)"), "()");
     }
     #[test]
     fn delete() {
         let env = lisp::Environment::new();
         do_lisp_env("(define a (list 10 10.5 3/5 \"ABC\" #\\a #t))", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete 10 a)", &env),
             "(10.5 3/5 \"ABC\" #\\a #t)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete 10.5 a)", &env),
             "(10 3/5 \"ABC\" #\\a #t)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete 3/5 a)", &env),
             "(10 10.5 \"ABC\" #\\a #t)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete \"ABC\" a)", &env),
             "(10 10.5 3/5 #\\a #t)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete #\\a a)", &env),
             "(10 10.5 3/5 \"ABC\" #t)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(delete #t a)", &env),
             "(10 10.5 3/5 \"ABC\" #\\a)"
         );
     }
     #[test]
     fn last() {
-        assert_str!(do_lisp("(last (list 1))"), "1");
-        assert_str!(do_lisp("(last (list 1 2))"), "2");
-        assert_str!(do_lisp("(last (cons 1 2))"), "1");
+        assert_eq!(do_lisp("(last (list 1))"), "1");
+        assert_eq!(do_lisp("(last (list 1 2))"), "2");
+        assert_eq!(do_lisp("(last (cons 1 2))"), "1");
     }
     #[test]
     fn reverse() {
-        assert_str!(do_lisp("(reverse (list 10))"), "(10)");
-        assert_str!(do_lisp("(reverse (iota 10))"), "(9 8 7 6 5 4 3 2 1 0)");
-        assert_str!(do_lisp("(reverse (list))"), "()");
+        assert_eq!(do_lisp("(reverse (list 10))"), "(10)");
+        assert_eq!(do_lisp("(reverse (iota 10))"), "(9 8 7 6 5 4 3 2 1 0)");
+        assert_eq!(do_lisp("(reverse (list))"), "()");
     }
     #[test]
     fn iota() {
-        assert_str!(do_lisp("(iota 10)"), "(0 1 2 3 4 5 6 7 8 9)");
-        assert_str!(do_lisp("(iota 10 1)"), "(1 2 3 4 5 6 7 8 9 10)");
-        assert_str!(do_lisp("(iota 1 10)"), "(10)");
-        assert_str!(do_lisp("(iota 10 1 2)"), "(1 3 5 7 9 11 13 15 17 19)");
-        assert_str!(do_lisp("(iota 10 1 -1)"), "(1 0 -1 -2 -3 -4 -5 -6 -7 -8)");
+        assert_eq!(do_lisp("(iota 10)"), "(0 1 2 3 4 5 6 7 8 9)");
+        assert_eq!(do_lisp("(iota 10 1)"), "(1 2 3 4 5 6 7 8 9 10)");
+        assert_eq!(do_lisp("(iota 1 10)"), "(10)");
+        assert_eq!(do_lisp("(iota 10 1 2)"), "(1 3 5 7 9 11 13 15 17 19)");
+        assert_eq!(do_lisp("(iota 10 1 -1)"), "(1 0 -1 -2 -3 -4 -5 -6 -7 -8)");
     }
     #[test]
     fn map() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(map (lambda (n) (* n 10)) (iota 10 1))"),
             "(10 20 30 40 50 60 70 80 90 100)"
         );
-        assert_str!(do_lisp("(map (lambda (n) (car n)) (list))"), "()");
+        assert_eq!(do_lisp("(map (lambda (n) (car n)) (list))"), "()");
 
-        assert_str!(
+        assert_eq!(
             do_lisp("(map (lambda (n) (car n)) (list (list 1)(list 2)(list 3)))"),
             "(1 2 3)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(map (lambda (n) (car n)) (list (list (list 1))(list 2)(list 3)))"),
             "((1) 2 3)"
         );
@@ -758,25 +751,25 @@ mod tests {
             &env,
         );
 
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 "(map (lambda (n)(map (lambda (m)(/ m 10)) n))(list (list 10 20 30)(list a b c)))",
                 &env
             ),
             "((1 2 3)(10 20 30))"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(map (lambda (n) (car n)) d)", &env),
             "((1)(2)(3))"
         );
     }
     #[test]
     fn filter() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(filter (lambda (n) (= 0 (modulo n 2))) (iota 10 1))"),
             "(2 4 6 8 10)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(filter (lambda (n) (not (= 0 (modulo n 2)))) (iota 10 1))"),
             "(1 3 5 7 9)"
         );
@@ -785,23 +778,23 @@ mod tests {
         do_lisp_env("(define a 100)", &env);
         do_lisp_env("(define b 200)", &env);
         do_lisp_env("(define c 300)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(filter (lambda (n) (= n 100)) (list a b c))", &env),
             "(100)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(filter (lambda (n) (not (= n 100))) (list a b c))", &env),
             "(200 300)"
         );
     }
     #[test]
     fn reduce() {
-        assert_str!(do_lisp("(reduce (lambda (a b) (+ a b))0(list 1 2 3))"), "6");
-        assert_str!(
+        assert_eq!(do_lisp("(reduce (lambda (a b) (+ a b))0(list 1 2 3))"), "6");
+        assert_eq!(
             do_lisp("(reduce (lambda (a b) (append a b))(list)(list (list 1) (list 2) (list 3)))"),
             "(1 2 3)"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(reduce (lambda (a b) (+ a b))(* 10 10)(list))"),
             "100"
         );
@@ -809,7 +802,7 @@ mod tests {
         do_lisp_env("(define a 100)", &env);
         do_lisp_env("(define b 200)", &env);
         do_lisp_env("(define c 300)", &env);
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(reduce (lambda (a b) (+ a b))0(list a b c))", &env),
             "600"
         );
@@ -819,189 +812,189 @@ mod tests {
         let env = lisp::Environment::new();
         do_lisp_env("(define c 0)", &env);
         do_lisp_env("(for-each (lambda (n) (set! c (+ c n)))(iota 5))", &env);
-        assert_str!(do_lisp_env("c", &env), "10");
+        assert_eq!(do_lisp_env("c", &env), "10");
     }
     #[test]
     fn list_ref() {
-        assert_str!(do_lisp("(list-ref (iota 10) 0)"), "0");
-        assert_str!(do_lisp("(list-ref (iota 10) 1)"), "1");
-        assert_str!(do_lisp("(list-ref (iota 10) 8)"), "8");
-        assert_str!(do_lisp("(list-ref (iota 10) 9)"), "9");
-        assert_str!(do_lisp("(list-ref '(#\\a #\\b #\\c) 1)"), "#\\b");
-        assert_str!(do_lisp("(list-ref (list (list 0 1) 1 2 3) 0)"), "(0 1)");
+        assert_eq!(do_lisp("(list-ref (iota 10) 0)"), "0");
+        assert_eq!(do_lisp("(list-ref (iota 10) 1)"), "1");
+        assert_eq!(do_lisp("(list-ref (iota 10) 8)"), "8");
+        assert_eq!(do_lisp("(list-ref (iota 10) 9)"), "9");
+        assert_eq!(do_lisp("(list-ref '(#\\a #\\b #\\c) 1)"), "#\\b");
+        assert_eq!(do_lisp("(list-ref (list (list 0 1) 1 2 3) 0)"), "(0 1)");
     }
     #[test]
     fn sqrt() {
-        assert_str!(do_lisp("(sqrt 9)"), "3");
-        assert_str!(do_lisp("(sqrt 25.0)"), "5");
+        assert_eq!(do_lisp("(sqrt 9)"), "3");
+        assert_eq!(do_lisp("(sqrt 25.0)"), "5");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 16)", &env);
-        assert_str!(do_lisp_env("(sqrt a)", &env), "4");
+        assert_eq!(do_lisp_env("(sqrt a)", &env), "4");
     }
     #[test]
     fn sin() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(sin (/(* 30 (* 4 (atan 1))) 180))"),
             "0.49999999999999994"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(sin (/(* 30.025 (* 4 (atan 1))) 180))"),
             "0.5003778272590873"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(sin (/(* 60 (* 4 (atan 1))) 180))"),
             "0.8660254037844386"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a (/(* 30 (* 4 (atan 1))) 180))", &env);
-        assert_str!(do_lisp_env("(sin a)", &env), "0.49999999999999994");
+        assert_eq!(do_lisp_env("(sin a)", &env), "0.49999999999999994");
     }
     #[test]
     fn cos() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(cos (/(* 30 (* 4 (atan 1))) 180))"),
             "0.8660254037844387"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(cos (/(* 60 (* 4 (atan 1))) 180))"),
             "0.5000000000000001"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(cos (/(* 59.725 (* 4 (atan 1))) 180))"),
             "0.5041508484218754"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a (/(* 60 (* 4 (atan 1))) 180))", &env);
-        assert_str!(do_lisp_env("(cos a)", &env), "0.5000000000000001");
+        assert_eq!(do_lisp_env("(cos a)", &env), "0.5000000000000001");
     }
     #[test]
     fn tan() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(tan (/(* 45 (* 4 (atan 1))) 180))"),
             "0.9999999999999999"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(tan (/(* 45.5 (* 4 (atan 1))) 180))"),
             "1.0176073929721252"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a (/(* 45 (* 4 (atan 1))) 180))", &env);
-        assert_str!(do_lisp_env("(tan a)", &env), "0.9999999999999999");
+        assert_eq!(do_lisp_env("(tan a)", &env), "0.9999999999999999");
     }
     #[test]
     fn asin() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(round (/ (* (asin (/(sqrt 3) 2)) 180)(*(atan 1)4)))"),
             "60"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(sin (asin (/(* pi 30)180)))"),
             do_lisp("(/(* pi 30)180)")
         );
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a (/(* pi 30)180))", &env);
-        assert_str!(do_lisp_env("(sin (asin a))", &env), do_lisp_env("a", &env));
+        assert_eq!(do_lisp_env("(sin (asin a))", &env), do_lisp_env("a", &env));
     }
     #[test]
     fn acos() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(round (/ (* (acos (/ 1 2)) 180)(*(atan 1)4)))"),
             "60"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("(cos (acos (/(* pi 30)180)))"),
             do_lisp("(/(* pi 30)180)")
         );
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a (/(* pi 30)180))", &env);
-        assert_str!(do_lisp_env("(cos (acos a))", &env), do_lisp_env("a", &env));
+        assert_eq!(do_lisp_env("(cos (acos a))", &env), do_lisp_env("a", &env));
     }
     #[test]
     fn atan() {
-        assert_str!(do_lisp("(round (/(* (atan 1) 180)(*(atan 1)4)))"), "45");
-        assert_str!(do_lisp("(* 4 (atan 1))"), "3.141592653589793");
-        assert_str!(do_lisp("(* 4 (atan 1.0))"), "3.141592653589793");
+        assert_eq!(do_lisp("(round (/(* (atan 1) 180)(*(atan 1)4)))"), "45");
+        assert_eq!(do_lisp("(* 4 (atan 1))"), "3.141592653589793");
+        assert_eq!(do_lisp("(* 4 (atan 1.0))"), "3.141592653589793");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 1)", &env);
-        assert_str!(do_lisp_env("(* 4 (atan a))", &env), "3.141592653589793");
+        assert_eq!(do_lisp_env("(* 4 (atan a))", &env), "3.141592653589793");
     }
     #[test]
     fn exp() {
-        assert_str!(do_lisp("(exp 1)"), "2.718281828459045");
-        assert_str!(do_lisp("(exp 1.025)"), "2.7870954605658507");
-        assert_str!(do_lisp("(exp 2)"), "7.38905609893065");
+        assert_eq!(do_lisp("(exp 1)"), "2.718281828459045");
+        assert_eq!(do_lisp("(exp 1.025)"), "2.7870954605658507");
+        assert_eq!(do_lisp("(exp 2)"), "7.38905609893065");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 3)", &env);
-        assert_str!(do_lisp_env("(exp a)", &env), "20.085536923187668");
+        assert_eq!(do_lisp_env("(exp a)", &env), "20.085536923187668");
     }
     #[test]
     fn log() {
-        assert_str!(do_lisp("(/(log 8)(log 2))"), "3");
-        assert_str!(do_lisp("(/(log 9.0)(log 3.0))"), "2");
-        assert_str!(do_lisp("(exp (/(log 8) 3))"), "2");
-        assert_str!(do_lisp("(round (exp (* (log 2) 3)))"), "8");
+        assert_eq!(do_lisp("(/(log 8)(log 2))"), "3");
+        assert_eq!(do_lisp("(/(log 9.0)(log 3.0))"), "2");
+        assert_eq!(do_lisp("(exp (/(log 8) 3))"), "2");
+        assert_eq!(do_lisp("(round (exp (* (log 2) 3)))"), "8");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a 9)", &env);
         do_lisp_env("(define b 3)", &env);
-        assert_str!(do_lisp_env("(/(log a)(log b))", &env), "2");
+        assert_eq!(do_lisp_env("(/(log a)(log b))", &env), "2");
     }
     #[test]
     fn truncate() {
-        assert_str!(do_lisp("(truncate 3.7)"), "3");
-        assert_str!(do_lisp("(truncate 3.1)"), "3");
-        assert_str!(do_lisp("(truncate -3.1)"), "-3");
-        assert_str!(do_lisp("(truncate -3.7)"), "-3");
+        assert_eq!(do_lisp("(truncate 3.7)"), "3");
+        assert_eq!(do_lisp("(truncate 3.1)"), "3");
+        assert_eq!(do_lisp("(truncate -3.1)"), "-3");
+        assert_eq!(do_lisp("(truncate -3.7)"), "-3");
     }
     #[test]
     fn floor() {
-        assert_str!(do_lisp("(floor 3.7)"), "3");
-        assert_str!(do_lisp("(floor 3.1)"), "3");
-        assert_str!(do_lisp("(floor -3.1)"), "-4");
-        assert_str!(do_lisp("(floor -3.7)"), "-4");
+        assert_eq!(do_lisp("(floor 3.7)"), "3");
+        assert_eq!(do_lisp("(floor 3.1)"), "3");
+        assert_eq!(do_lisp("(floor -3.1)"), "-4");
+        assert_eq!(do_lisp("(floor -3.7)"), "-4");
     }
     #[test]
     fn ceiling() {
-        assert_str!(do_lisp("(ceiling 3.7)"), "4");
-        assert_str!(do_lisp("(ceiling 3.1)"), "4");
-        assert_str!(do_lisp("(ceiling -3.1)"), "-3");
-        assert_str!(do_lisp("(ceiling -3.7)"), "-3");
+        assert_eq!(do_lisp("(ceiling 3.7)"), "4");
+        assert_eq!(do_lisp("(ceiling 3.1)"), "4");
+        assert_eq!(do_lisp("(ceiling -3.1)"), "-3");
+        assert_eq!(do_lisp("(ceiling -3.7)"), "-3");
     }
     #[test]
     fn round() {
-        assert_str!(do_lisp("(round 3.7)"), "4");
-        assert_str!(do_lisp("(round 3.1)"), "3");
-        assert_str!(do_lisp("(round -3.1)"), "-3");
-        assert_str!(do_lisp("(round -3.7)"), "-4");
+        assert_eq!(do_lisp("(round 3.7)"), "4");
+        assert_eq!(do_lisp("(round 3.1)"), "3");
+        assert_eq!(do_lisp("(round -3.1)"), "-3");
+        assert_eq!(do_lisp("(round -3.7)"), "-4");
     }
     #[test]
     fn abs() {
-        assert_str!(do_lisp("(abs -20)"), "20");
-        assert_str!(do_lisp("(abs  20)"), "20");
-        assert_str!(do_lisp("(abs -1.5)"), "1.5");
-        assert_str!(do_lisp("(abs  1.5)"), "1.5");
-        assert_str!(do_lisp("(abs -1/3)"), "1/3");
-        assert_str!(do_lisp("(abs  1/3)"), "1/3");
+        assert_eq!(do_lisp("(abs -20)"), "20");
+        assert_eq!(do_lisp("(abs  20)"), "20");
+        assert_eq!(do_lisp("(abs -1.5)"), "1.5");
+        assert_eq!(do_lisp("(abs  1.5)"), "1.5");
+        assert_eq!(do_lisp("(abs -1/3)"), "1/3");
+        assert_eq!(do_lisp("(abs  1/3)"), "1/3");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a -20)", &env);
         do_lisp_env("(define b -1.5)", &env);
-        assert_str!(do_lisp_env("(+ (abs a)(abs b))", &env), "21.5");
+        assert_eq!(do_lisp_env("(+ (abs a)(abs b))", &env), "21.5");
     }
     #[test]
     fn rand_integer() {
-        assert_str!(do_lisp("(integer? (rand-integer))"), "#t");
-        assert_str!(do_lisp("(* 0 (rand-integer))"), "0");
+        assert_eq!(do_lisp("(integer? (rand-integer))"), "#t");
+        assert_eq!(do_lisp("(* 0 (rand-integer))"), "0");
     }
     #[test]
     fn rand_list() {
-        assert_str!(do_lisp("(length (rand-list 4))"), "4");
-        assert_str!(
+        assert_eq!(do_lisp("(length (rand-list 4))"), "4");
+        assert_eq!(
             do_lisp("(map (lambda (n) (integer? n)) (rand-list 4))"),
             "(#t #t #t #t)"
         );
@@ -1026,147 +1019,147 @@ mod tests {
         let env = lisp::Environment::new();
         let f = test_file.as_path().to_str().expect("die");
         do_lisp_env(format!("(load-file \"{}\")", f).as_str(), &env);
-        assert_str!(do_lisp_env("foo", &env), "100");
-        assert_str!(do_lisp_env("hoge", &env), "200");
-        assert_str!(do_lisp_env("fuga", &env), "300");
-        assert_str!(do_lisp_env("(+ a b c)", &env), "600");
+        assert_eq!(do_lisp_env("foo", &env), "100");
+        assert_eq!(do_lisp_env("hoge", &env), "200");
+        assert_eq!(do_lisp_env("fuga", &env), "300");
+        assert_eq!(do_lisp_env("(+ a b c)", &env), "600");
     }
     #[test]
     fn delay_force() {
-        assert_str!(do_lisp("(delay (+ 1 1))"), "Promise");
-        assert_str!(do_lisp("(force (delay (+ 1 1)))"), "2");
-        assert_str!(do_lisp("(force  (+ 1 2))"), "3");
+        assert_eq!(do_lisp("(delay (+ 1 1))"), "Promise");
+        assert_eq!(do_lisp("(force (delay (+ 1 1)))"), "2");
+        assert_eq!(do_lisp("(force  (+ 1 2))"), "3");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define p (delay (+ 2 3)))", &env);
-        assert_str!(do_lisp_env("(force p)", &env), "5");
+        assert_eq!(do_lisp_env("(force p)", &env), "5");
     }
     #[test]
     fn test_add_rational() {
-        assert_str!(do_lisp("(+ 1 1/2)"), "3/2");
-        assert_str!(do_lisp("(+ 2.5 1/4)"), "2.75");
-        assert_str!(do_lisp("(+ 3/4 1)"), "7/4");
-        assert_str!(do_lisp("(+ 1/4 2.5)"), "2.75");
-        assert_str!(do_lisp("(+ 3/4 1/3)"), "13/12");
-        assert_str!(do_lisp("(+ -1/3 1/3)"), "0");
+        assert_eq!(do_lisp("(+ 1 1/2)"), "3/2");
+        assert_eq!(do_lisp("(+ 2.5 1/4)"), "2.75");
+        assert_eq!(do_lisp("(+ 3/4 1)"), "7/4");
+        assert_eq!(do_lisp("(+ 1/4 2.5)"), "2.75");
+        assert_eq!(do_lisp("(+ 3/4 1/3)"), "13/12");
+        assert_eq!(do_lisp("(+ -1/3 1/3)"), "0");
     }
     #[test]
     fn test_sub_rational() {
-        assert_str!(do_lisp("(- 1 1/2)"), "1/2");
-        assert_str!(do_lisp("(- 2.5 1/4)"), "2.25");
-        assert_str!(do_lisp("(- 1/2 1)"), "-1/2");
-        assert_str!(do_lisp("(- 3/4 0.5)"), "0.25");
-        assert_str!(do_lisp("(- 3/4 1/2)"), "1/4");
+        assert_eq!(do_lisp("(- 1 1/2)"), "1/2");
+        assert_eq!(do_lisp("(- 2.5 1/4)"), "2.25");
+        assert_eq!(do_lisp("(- 1/2 1)"), "-1/2");
+        assert_eq!(do_lisp("(- 3/4 0.5)"), "0.25");
+        assert_eq!(do_lisp("(- 3/4 1/2)"), "1/4");
     }
     #[test]
     fn test_mul_rational() {
-        assert_str!(do_lisp("(* 3 1/2)"), "3/2");
-        assert_str!(do_lisp("(* 2.5 1/4)"), "0.625");
-        assert_str!(do_lisp("(* 1/2 3)"), "3/2");
-        assert_str!(do_lisp("(* 3/4 0.5)"), "0.375");
-        assert_str!(do_lisp("(* 3/4 1/2)"), "3/8");
+        assert_eq!(do_lisp("(* 3 1/2)"), "3/2");
+        assert_eq!(do_lisp("(* 2.5 1/4)"), "0.625");
+        assert_eq!(do_lisp("(* 1/2 3)"), "3/2");
+        assert_eq!(do_lisp("(* 3/4 0.5)"), "0.375");
+        assert_eq!(do_lisp("(* 3/4 1/2)"), "3/8");
     }
     #[test]
     fn test_div_rational() {
-        assert_str!(do_lisp("(/ 3 1/2)"), "6");
-        assert_str!(do_lisp("(/ 2.5 1/3)"), "7.5");
-        assert_str!(do_lisp("(/ 1/2 3)"), "1/6");
-        assert_str!(do_lisp("(/ 3/4 0.5)"), "1.5");
-        assert_str!(do_lisp("(/ 3/4 1/2)"), "3/2");
+        assert_eq!(do_lisp("(/ 3 1/2)"), "6");
+        assert_eq!(do_lisp("(/ 2.5 1/3)"), "7.5");
+        assert_eq!(do_lisp("(/ 1/2 3)"), "1/6");
+        assert_eq!(do_lisp("(/ 3/4 0.5)"), "1.5");
+        assert_eq!(do_lisp("(/ 3/4 1/2)"), "3/2");
     }
     #[test]
     fn test_eq_rational() {
-        assert_str!(do_lisp("(= 3 6/2)"), "#t");
-        assert_str!(do_lisp("(= 0.5 1/2)"), "#t");
-        assert_str!(do_lisp("(= 6/2 3)"), "#t");
-        assert_str!(do_lisp("(= 3/2 1.5)"), "#t");
-        assert_str!(do_lisp("(= 4/8 2/4)"), "#t");
+        assert_eq!(do_lisp("(= 3 6/2)"), "#t");
+        assert_eq!(do_lisp("(= 0.5 1/2)"), "#t");
+        assert_eq!(do_lisp("(= 6/2 3)"), "#t");
+        assert_eq!(do_lisp("(= 3/2 1.5)"), "#t");
+        assert_eq!(do_lisp("(= 4/8 2/4)"), "#t");
     }
 
     #[test]
     fn test_lt_rational() {
-        assert_str!(do_lisp("(< 3 7/2)"), "#t");
-        assert_str!(do_lisp("(< 0.3 1/2)"), "#t");
-        assert_str!(do_lisp("(< 6/2 4)"), "#t");
-        assert_str!(do_lisp("(< 4/8 3/4)"), "#t");
+        assert_eq!(do_lisp("(< 3 7/2)"), "#t");
+        assert_eq!(do_lisp("(< 0.3 1/2)"), "#t");
+        assert_eq!(do_lisp("(< 6/2 4)"), "#t");
+        assert_eq!(do_lisp("(< 4/8 3/4)"), "#t");
     }
 
     #[test]
     fn test_le_rational() {
-        assert_str!(do_lisp("(<= 3 7/2)"), "#t");
-        assert_str!(do_lisp("(<= 0.3 1/2)"), "#t");
-        assert_str!(do_lisp("(<= 6/2 4)"), "#t");
-        assert_str!(do_lisp("(<= 4/8 3/4)"), "#t");
+        assert_eq!(do_lisp("(<= 3 7/2)"), "#t");
+        assert_eq!(do_lisp("(<= 0.3 1/2)"), "#t");
+        assert_eq!(do_lisp("(<= 6/2 4)"), "#t");
+        assert_eq!(do_lisp("(<= 4/8 3/4)"), "#t");
 
-        assert_str!(do_lisp("(<= 3 6/2)"), "#t");
-        assert_str!(do_lisp("(<= 0.5 1/2)"), "#t");
-        assert_str!(do_lisp("(<= 6/2 3)"), "#t");
-        assert_str!(do_lisp("(<= 3/2 1.5)"), "#t");
-        assert_str!(do_lisp("(<= 4/8 2/4)"), "#t");
+        assert_eq!(do_lisp("(<= 3 6/2)"), "#t");
+        assert_eq!(do_lisp("(<= 0.5 1/2)"), "#t");
+        assert_eq!(do_lisp("(<= 6/2 3)"), "#t");
+        assert_eq!(do_lisp("(<= 3/2 1.5)"), "#t");
+        assert_eq!(do_lisp("(<= 4/8 2/4)"), "#t");
     }
 
     #[test]
     fn test_gt_rational() {
-        assert_str!(do_lisp("(> 7/2 3)"), "#t");
-        assert_str!(do_lisp("(> 1/2 0.3)"), "#t");
-        assert_str!(do_lisp("(> 4 6/2)"), "#t");
-        assert_str!(do_lisp("(> 1.6 3/2)"), "#t");
-        assert_str!(do_lisp("(> 3/4 4/8)"), "#t");
+        assert_eq!(do_lisp("(> 7/2 3)"), "#t");
+        assert_eq!(do_lisp("(> 1/2 0.3)"), "#t");
+        assert_eq!(do_lisp("(> 4 6/2)"), "#t");
+        assert_eq!(do_lisp("(> 1.6 3/2)"), "#t");
+        assert_eq!(do_lisp("(> 3/4 4/8)"), "#t");
     }
     #[test]
     fn test_ge_rational() {
-        assert_str!(do_lisp("(>= 7/2 3)"), "#t");
-        assert_str!(do_lisp("(>= 1/2 0.3)"), "#t");
-        assert_str!(do_lisp("(>= 4 6/2)"), "#t");
-        assert_str!(do_lisp("(>= 1.6 3/2)"), "#t");
-        assert_str!(do_lisp("(>= 3/4 4/8)"), "#t");
+        assert_eq!(do_lisp("(>= 7/2 3)"), "#t");
+        assert_eq!(do_lisp("(>= 1/2 0.3)"), "#t");
+        assert_eq!(do_lisp("(>= 4 6/2)"), "#t");
+        assert_eq!(do_lisp("(>= 1.6 3/2)"), "#t");
+        assert_eq!(do_lisp("(>= 3/4 4/8)"), "#t");
 
-        assert_str!(do_lisp("(>= 3 6/2)"), "#t");
-        assert_str!(do_lisp("(>= 0.5 1/2)"), "#t");
-        assert_str!(do_lisp("(>= 6/2 3)"), "#t");
-        assert_str!(do_lisp("(>= 3/2 1.5)"), "#t");
-        assert_str!(do_lisp("(>= 4/8 2/4)"), "#t");
+        assert_eq!(do_lisp("(>= 3 6/2)"), "#t");
+        assert_eq!(do_lisp("(>= 0.5 1/2)"), "#t");
+        assert_eq!(do_lisp("(>= 6/2 3)"), "#t");
+        assert_eq!(do_lisp("(>= 3/2 1.5)"), "#t");
+        assert_eq!(do_lisp("(>= 4/8 2/4)"), "#t");
     }
     #[test]
     fn display() {
         let env = lisp::Environment::new();
         do_lisp_env("(define a 100)", &env);
-        assert_str!(do_lisp_env("(display a)", &env), "nil");
+        assert_eq!(do_lisp_env("(display a)", &env), "nil");
     }
     #[test]
     fn newline() {
-        assert_str!(do_lisp("(newline)"), "nil");
+        assert_eq!(do_lisp("(newline)"), "nil");
     }
     #[test]
     fn begin() {
-        assert_str!(do_lisp("(begin (list 1 2)(list 3 4)(list 5 6))"), "(5 6)");
+        assert_eq!(do_lisp("(begin (list 1 2)(list 3 4)(list 5 6))"), "(5 6)");
     }
     #[test]
     fn sequence() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(let ((i 0)) (define i 100) (set! i (+ i 1)) i)"),
             "101"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("((lambda (a) (define i 100) (set! i (+ i a)) i)10)"),
             "110"
         );
     }
     #[test]
     fn format_f() {
-        assert_str!(do_lisp("(format \"~D\" 10)"), "\"10\"");
-        assert_str!(do_lisp("(format \"~d\" 10)"), "\"10\"");
-        assert_str!(do_lisp("(format \"~X\" 10)"), "\"A\"");
-        assert_str!(do_lisp("(format \"~x\" 10)"), "\"a\"");
-        assert_str!(do_lisp("(format \"~O\" 10)"), "\"12\"");
-        assert_str!(do_lisp("(format \"~o\" 10)"), "\"12\"");
-        assert_str!(do_lisp("(format \"~B\" 10)"), "\"1010\"");
-        assert_str!(do_lisp("(format \"~b\" 10)"), "\"1010\"");
+        assert_eq!(do_lisp("(format \"~D\" 10)"), "\"10\"");
+        assert_eq!(do_lisp("(format \"~d\" 10)"), "\"10\"");
+        assert_eq!(do_lisp("(format \"~X\" 10)"), "\"A\"");
+        assert_eq!(do_lisp("(format \"~x\" 10)"), "\"a\"");
+        assert_eq!(do_lisp("(format \"~O\" 10)"), "\"12\"");
+        assert_eq!(do_lisp("(format \"~o\" 10)"), "\"12\"");
+        assert_eq!(do_lisp("(format \"~B\" 10)"), "\"1010\"");
+        assert_eq!(do_lisp("(format \"~b\" 10)"), "\"1010\"");
 
         let env = lisp::Environment::new();
         do_lisp_env("(define a \"~D\")", &env);
         do_lisp_env("(define b 100)", &env);
-        assert_str!(do_lisp_env("(format a b)", &env), "\"100\"");
+        assert_eq!(do_lisp_env("(format a b)", &env), "\"100\"");
     }
     #[test]
     fn force_stop() {
@@ -1174,9 +1167,9 @@ mod tests {
         assert!(env.is_force_stop() == false);
         do_lisp_env("( force-stop )", &env);
         assert!(env.is_force_stop() == true);
-        assert_str!(do_lisp_env("a", &env), "E9000");
+        assert_eq!(do_lisp_env("a", &env), "E9000");
         env.set_force_stop(false);
-        assert_str!(do_lisp_env("100", &env), "100");
+        assert_eq!(do_lisp_env("100", &env), "100");
     }
     #[test]
     fn set_tail_recursion() {
@@ -1189,152 +1182,152 @@ mod tests {
     }
     #[test]
     fn string_eq() {
-        assert_str!(do_lisp("(string=? \"abc\" \"abc\")"), "#t");
-        assert_str!(do_lisp("(string=? \"abc\" \"ABC\")"), "#f");
+        assert_eq!(do_lisp("(string=? \"abc\" \"abc\")"), "#t");
+        assert_eq!(do_lisp("(string=? \"abc\" \"ABC\")"), "#f");
     }
     #[test]
     fn string_less() {
-        assert_str!(do_lisp("(string<? \"1234\" \"9\")"), "#t");
-        assert_str!(do_lisp("(string<? \"9\" \"1234\")"), "#f");
+        assert_eq!(do_lisp("(string<? \"1234\" \"9\")"), "#t");
+        assert_eq!(do_lisp("(string<? \"9\" \"1234\")"), "#f");
     }
     #[test]
     fn string_than() {
-        assert_str!(do_lisp("(string>? \"9\" \"1234\")"), "#t");
-        assert_str!(do_lisp("(string>? \"1234\" \"9\")"), "#f");
+        assert_eq!(do_lisp("(string>? \"9\" \"1234\")"), "#t");
+        assert_eq!(do_lisp("(string>? \"1234\" \"9\")"), "#f");
     }
     #[test]
     fn string_le() {
-        assert_str!(do_lisp("(string<=? \"1234\" \"9\")"), "#t");
-        assert_str!(do_lisp("(string<=? \"1234\" \"1234\")"), "#t");
-        assert_str!(do_lisp("(string<=? \"9\" \"1234\")"), "#f");
+        assert_eq!(do_lisp("(string<=? \"1234\" \"9\")"), "#t");
+        assert_eq!(do_lisp("(string<=? \"1234\" \"1234\")"), "#t");
+        assert_eq!(do_lisp("(string<=? \"9\" \"1234\")"), "#f");
     }
     #[test]
     fn string_ge() {
-        assert_str!(do_lisp("(string>=?  \"9\" \"1234\")"), "#t");
-        assert_str!(do_lisp("(string>=?  \"1234\" \"1234\")"), "#t");
-        assert_str!(do_lisp("(string>=?  \"1234\" \"9\")"), "#f");
+        assert_eq!(do_lisp("(string>=?  \"9\" \"1234\")"), "#t");
+        assert_eq!(do_lisp("(string>=?  \"1234\" \"1234\")"), "#t");
+        assert_eq!(do_lisp("(string>=?  \"1234\" \"9\")"), "#f");
     }
     #[test]
     fn char_eq() {
-        assert_str!(do_lisp("(char=? #\\a #\\a)"), "#t");
-        assert_str!(do_lisp("(char=? #\\a #\\b)"), "#f");
+        assert_eq!(do_lisp("(char=? #\\a #\\a)"), "#t");
+        assert_eq!(do_lisp("(char=? #\\a #\\b)"), "#f");
     }
     #[test]
     fn char_less() {
-        assert_str!(do_lisp("(char<? #\\a #\\b)"), "#t");
-        assert_str!(do_lisp("(char<? #\\b #\\a)"), "#f");
+        assert_eq!(do_lisp("(char<? #\\a #\\b)"), "#t");
+        assert_eq!(do_lisp("(char<? #\\b #\\a)"), "#f");
     }
     #[test]
     fn char_than() {
-        assert_str!(do_lisp("(char>? #\\b #\\a)"), "#t");
-        assert_str!(do_lisp("(char>? #\\a #\\b)"), "#f");
+        assert_eq!(do_lisp("(char>? #\\b #\\a)"), "#t");
+        assert_eq!(do_lisp("(char>? #\\a #\\b)"), "#f");
     }
     #[test]
     fn char_le() {
-        assert_str!(do_lisp("(char<=? #\\a #\\b)"), "#t");
-        assert_str!(do_lisp("(char<=? #\\a #\\a)"), "#t");
-        assert_str!(do_lisp("(char<=? #\\b #\\a)"), "#f");
+        assert_eq!(do_lisp("(char<=? #\\a #\\b)"), "#t");
+        assert_eq!(do_lisp("(char<=? #\\a #\\a)"), "#t");
+        assert_eq!(do_lisp("(char<=? #\\b #\\a)"), "#f");
     }
     #[test]
     fn char_ge() {
-        assert_str!(do_lisp("(char>=? #\\b #\\a)"), "#t");
-        assert_str!(do_lisp("(char>=? #\\a #\\a)"), "#t");
-        assert_str!(do_lisp("(char>=? #\\a #\\b)"), "#f");
+        assert_eq!(do_lisp("(char>=? #\\b #\\a)"), "#t");
+        assert_eq!(do_lisp("(char>=? #\\a #\\a)"), "#t");
+        assert_eq!(do_lisp("(char>=? #\\a #\\b)"), "#f");
     }
     #[test]
     fn str_append() {
-        assert_str!(do_lisp("(string-append \"ABC\" \"DEF\")"), "\"ABCDEF\"");
-        assert_str!(
+        assert_eq!(do_lisp("(string-append \"ABC\" \"DEF\")"), "\"ABCDEF\"");
+        assert_eq!(
             do_lisp("(string-append \"ABC\" \"DEF\" \"123\")"),
             "\"ABCDEF123\""
         );
     }
     #[test]
     fn string_length() {
-        assert_str!(do_lisp("(string-length \"\")"), "0");
-        assert_str!(do_lisp("(string-length \"1234567890\")"), "10");
-        assert_str!(do_lisp("(string-length \"山\")"), "1");
+        assert_eq!(do_lisp("(string-length \"\")"), "0");
+        assert_eq!(do_lisp("(string-length \"1234567890\")"), "10");
+        assert_eq!(do_lisp("(string-length \"山\")"), "1");
     }
     #[test]
     fn string_size() {
-        assert_str!(do_lisp("(string-size \"\")"), "0");
-        assert_str!(do_lisp("(string-size \"1234567890\")"), "10");
-        assert_str!(do_lisp("(string-size \"山\")"), "3");
+        assert_eq!(do_lisp("(string-size \"\")"), "0");
+        assert_eq!(do_lisp("(string-size \"1234567890\")"), "10");
+        assert_eq!(do_lisp("(string-size \"山\")"), "3");
     }
     #[test]
     fn number_string() {
-        assert_str!(do_lisp("(number->string 10)"), "\"10\"");
-        assert_str!(do_lisp("(number->string 10.5)"), "\"10.5\"");
-        assert_str!(do_lisp("(number->string 1/3)"), "\"1/3\"");
+        assert_eq!(do_lisp("(number->string 10)"), "\"10\"");
+        assert_eq!(do_lisp("(number->string 10.5)"), "\"10.5\"");
+        assert_eq!(do_lisp("(number->string 1/3)"), "\"1/3\"");
     }
     #[test]
     fn string_number() {
-        assert_str!(do_lisp("(string->number \"123\")"), "123");
-        assert_str!(do_lisp("(string->number \"10.5\")"), "10.5");
-        assert_str!(do_lisp("(string->number \"1/3\")"), "1/3");
+        assert_eq!(do_lisp("(string->number \"123\")"), "123");
+        assert_eq!(do_lisp("(string->number \"10.5\")"), "10.5");
+        assert_eq!(do_lisp("(string->number \"1/3\")"), "1/3");
     }
     #[test]
     fn list_string() {
-        assert_str!(do_lisp("(list->string (list))"), "\"\"");
-        assert_str!(do_lisp("(list->string (list #\\a #\\b #\\c))"), "\"abc\"");
+        assert_eq!(do_lisp("(list->string (list))"), "\"\"");
+        assert_eq!(do_lisp("(list->string (list #\\a #\\b #\\c))"), "\"abc\"");
     }
     #[test]
     fn string_list() {
-        assert_str!(do_lisp("(string->list \"\")"), "()");
-        assert_str!(do_lisp("(string->list \"abc\")"), "(#\\a #\\b #\\c)");
-        assert_str!(do_lisp("(string->list \"山田\")"), "(#\\山 #\\田)");
+        assert_eq!(do_lisp("(string->list \"\")"), "()");
+        assert_eq!(do_lisp("(string->list \"abc\")"), "(#\\a #\\b #\\c)");
+        assert_eq!(do_lisp("(string->list \"山田\")"), "(#\\山 #\\田)");
     }
     #[test]
     fn substring() {
-        assert_str!(do_lisp("(substring \"1234567890\" 1 2)"), "\"2\"");
-        assert_str!(do_lisp("(substring \"1234567890\" 1 3)"), "\"23\"");
-        assert_str!(do_lisp("(substring \"1234567890\" 0 10)"), "\"1234567890\"");
-        assert_str!(do_lisp("(substring \"山\" 0 1)"), "\"山\"");
-        assert_str!(do_lisp("(substring \"山1\" 0 2)"), "\"山1\"");
+        assert_eq!(do_lisp("(substring \"1234567890\" 1 2)"), "\"2\"");
+        assert_eq!(do_lisp("(substring \"1234567890\" 1 3)"), "\"23\"");
+        assert_eq!(do_lisp("(substring \"1234567890\" 0 10)"), "\"1234567890\"");
+        assert_eq!(do_lisp("(substring \"山\" 0 1)"), "\"山\"");
+        assert_eq!(do_lisp("(substring \"山1\" 0 2)"), "\"山1\"");
     }
     #[test]
     fn symbol_string() {
-        assert_str!(do_lisp("(symbol->string 'abc)"), "\"abc\"");
+        assert_eq!(do_lisp("(symbol->string 'abc)"), "\"abc\"");
     }
     #[test]
     fn string_symbol() {
-        assert_str!(do_lisp("(string->symbol \"abc\")"), "abc");
+        assert_eq!(do_lisp("(string->symbol \"abc\")"), "abc");
     }
     #[test]
     fn make_string() {
-        assert_str!(do_lisp("(make-string 4 #\\a)"), "\"aaaa\"");
-        assert_str!(do_lisp("(make-string 4 #\\山)"), "\"山山山山\"");
+        assert_eq!(do_lisp("(make-string 4 #\\a)"), "\"aaaa\"");
+        assert_eq!(do_lisp("(make-string 4 #\\山)"), "\"山山山山\"");
     }
     #[test]
     fn integer_char() {
-        assert_str!(do_lisp("(integer->char 65)"), "#\\A");
-        assert_str!(do_lisp("(integer->char 23665)"), "#\\山");
+        assert_eq!(do_lisp("(integer->char 65)"), "#\\A");
+        assert_eq!(do_lisp("(integer->char 23665)"), "#\\山");
     }
     #[test]
     fn char_integer() {
-        assert_str!(do_lisp("(char->integer #\\A)"), "65");
-        assert_str!(do_lisp("(char->integer #\\山)"), "23665");
+        assert_eq!(do_lisp("(char->integer #\\A)"), "65");
+        assert_eq!(do_lisp("(char->integer #\\山)"), "23665");
     }
     #[test]
     fn quote() {
-        assert_str!(do_lisp("(quote 1)"), "1");
-        assert_str!(do_lisp("(quote \"abc\")"), "\"abc\"");
-        assert_str!(do_lisp("(quote a)"), "a");
-        assert_str!(do_lisp("(quote (a b c))"), "(a b c)");
+        assert_eq!(do_lisp("(quote 1)"), "1");
+        assert_eq!(do_lisp("(quote \"abc\")"), "\"abc\"");
+        assert_eq!(do_lisp("(quote a)"), "a");
+        assert_eq!(do_lisp("(quote (a b c))"), "(a b c)");
 
-        assert_str!(do_lisp("' a"), "a");
-        assert_str!(do_lisp("'abc"), "abc");
-        assert_str!(do_lisp("'\"abc\""), "\"abc\"");
-        assert_str!(do_lisp("'\"abc\" '\"def\""), "\"def\"");
-        assert_str!(do_lisp("'(a b c)"), "(a b c)");
-        assert_str!(
+        assert_eq!(do_lisp("' a"), "a");
+        assert_eq!(do_lisp("'abc"), "abc");
+        assert_eq!(do_lisp("'\"abc\""), "\"abc\"");
+        assert_eq!(do_lisp("'\"abc\" '\"def\""), "\"def\"");
+        assert_eq!(do_lisp("'(a b c)"), "(a b c)");
+        assert_eq!(
             do_lisp("'(a b c (d e f (g h i)))"),
             "(a b c (d e f (g h i)))"
         );
     }
     #[test]
     fn get_env() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(get-environment-variable \"HOME\")"),
             format!("\"{}\"", env::var("HOME").unwrap())
         );
@@ -1347,341 +1340,341 @@ mod error_tests {
 
     #[test]
     fn syntax_error() {
-        assert_str!(do_lisp("("), "E0001");
-        assert_str!(do_lisp(")"), "E0003");
-        assert_str!(do_lisp("(list (+ 1 2) 3"), "E0002");
+        assert_eq!(do_lisp("("), "E0001");
+        assert_eq!(do_lisp(")"), "E0003");
+        assert_eq!(do_lisp("(list (+ 1 2) 3"), "E0002");
     }
     #[test]
     fn atom() {
-        assert_str!(do_lisp("\""), "E0004");
-        assert_str!(do_lisp("\"a"), "E0004");
-        assert_str!(do_lisp("a\""), "E0004");
-        assert_str!(do_lisp("3/0"), "E1013");
+        assert_eq!(do_lisp("\""), "E0004");
+        assert_eq!(do_lisp("\"a"), "E0004");
+        assert_eq!(do_lisp("a\""), "E0004");
+        assert_eq!(do_lisp("3/0"), "E1013");
     }
     #[test]
     fn atom_utf8() {
-        assert_str!(do_lisp("\"山"), "E0004");
-        assert_str!(do_lisp("山"), "E1008");
+        assert_eq!(do_lisp("\"山"), "E0004");
+        assert_eq!(do_lisp("山"), "E1008");
     }
     #[test]
     fn plus() {
-        assert_str!(do_lisp("(+ 1 a)"), "E1008");
-        assert_str!(do_lisp("(+ 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(+ 1)"), "E1007");
+        assert_eq!(do_lisp("(+ 1 a)"), "E1008");
+        assert_eq!(do_lisp("(+ 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(+ 1)"), "E1007");
     }
     #[test]
     fn minus() {
-        assert_str!(do_lisp("(- 6 a)"), "E1008");
-        assert_str!(do_lisp("(- 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(- 1)"), "E1007");
+        assert_eq!(do_lisp("(- 6 a)"), "E1008");
+        assert_eq!(do_lisp("(- 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(- 1)"), "E1007");
     }
     #[test]
     fn multi() {
-        assert_str!(do_lisp("(* 6 a)"), "E1008");
-        assert_str!(do_lisp("(* 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(* 1)"), "E1007");
+        assert_eq!(do_lisp("(* 6 a)"), "E1008");
+        assert_eq!(do_lisp("(* 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(* 1)"), "E1007");
     }
     #[test]
     fn div() {
-        assert_str!(do_lisp("(/ 9 a)"), "E1008");
-        assert_str!(do_lisp("(/ 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(/ 1)"), "E1007");
+        assert_eq!(do_lisp("(/ 9 a)"), "E1008");
+        assert_eq!(do_lisp("(/ 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(/ 1)"), "E1007");
     }
     #[test]
     fn max_f() {
-        assert_str!(do_lisp("(max 10)"), "E1007");
-        assert_str!(do_lisp("(max 9 a)"), "E1008");
-        assert_str!(do_lisp("(max 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(max 1)"), "E1007");
+        assert_eq!(do_lisp("(max 10)"), "E1007");
+        assert_eq!(do_lisp("(max 9 a)"), "E1008");
+        assert_eq!(do_lisp("(max 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(max 1)"), "E1007");
     }
     #[test]
     fn min_f() {
-        assert_str!(do_lisp("(min 10)"), "E1007");
-        assert_str!(do_lisp("(min 9 a)"), "E1008");
-        assert_str!(do_lisp("(min 1 3.4 #t)"), "E1003");
-        assert_str!(do_lisp("(min 1)"), "E1007");
+        assert_eq!(do_lisp("(min 10)"), "E1007");
+        assert_eq!(do_lisp("(min 9 a)"), "E1008");
+        assert_eq!(do_lisp("(min 1 3.4 #t)"), "E1003");
+        assert_eq!(do_lisp("(min 1)"), "E1007");
     }
     #[test]
     fn eq() {
-        assert_str!(do_lisp("(= 5)"), "E1007");
-        assert_str!(do_lisp("(= 5 a)"), "E1008");
-        assert_str!(do_lisp("(= 5 #f)"), "E1003");
+        assert_eq!(do_lisp("(= 5)"), "E1007");
+        assert_eq!(do_lisp("(= 5 a)"), "E1008");
+        assert_eq!(do_lisp("(= 5 #f)"), "E1003");
     }
     #[test]
     fn than() {
-        assert_str!(do_lisp("(> 6)"), "E1007");
-        assert_str!(do_lisp("(> 6 a)"), "E1008");
-        assert_str!(do_lisp("(> 6 #f)"), "E1003");
+        assert_eq!(do_lisp("(> 6)"), "E1007");
+        assert_eq!(do_lisp("(> 6 a)"), "E1008");
+        assert_eq!(do_lisp("(> 6 #f)"), "E1003");
     }
     #[test]
     fn less() {
-        assert_str!(do_lisp("(< 5)"), "E1007");
-        assert_str!(do_lisp("(< 5 a)"), "E1008");
-        assert_str!(do_lisp("(< 5 #f)"), "E1003");
+        assert_eq!(do_lisp("(< 5)"), "E1007");
+        assert_eq!(do_lisp("(< 5 a)"), "E1008");
+        assert_eq!(do_lisp("(< 5 #f)"), "E1003");
     }
     #[test]
     fn than_eq() {
-        assert_str!(do_lisp("(>= 6)"), "E1007");
-        assert_str!(do_lisp("(>= 6 a)"), "E1008");
-        assert_str!(do_lisp("(>= 6 #t)"), "E1003");
+        assert_eq!(do_lisp("(>= 6)"), "E1007");
+        assert_eq!(do_lisp("(>= 6 a)"), "E1008");
+        assert_eq!(do_lisp("(>= 6 #t)"), "E1003");
     }
     #[test]
     fn less_eq() {
-        assert_str!(do_lisp("(<= 6)"), "E1007");
-        assert_str!(do_lisp("(<= 6 a)"), "E1008");
-        assert_str!(do_lisp("(<= 6 #t)"), "E1003");
+        assert_eq!(do_lisp("(<= 6)"), "E1007");
+        assert_eq!(do_lisp("(<= 6 a)"), "E1008");
+        assert_eq!(do_lisp("(<= 6 #t)"), "E1003");
     }
     #[test]
     fn ash() {
-        assert_str!(do_lisp("(ash)"), "E1007");
-        assert_str!(do_lisp("(ash 10)"), "E1007");
-        assert_str!(do_lisp("(ash 10 1 1)"), "E1007");
-        assert_str!(do_lisp("(ash a 1)"), "E1008");
-        assert_str!(do_lisp("(ash 10 a)"), "E1008");
-        assert_str!(do_lisp("(ash 10.5 1)"), "E1002");
-        assert_str!(do_lisp("(ash 10 1.5)"), "E1002");
+        assert_eq!(do_lisp("(ash)"), "E1007");
+        assert_eq!(do_lisp("(ash 10)"), "E1007");
+        assert_eq!(do_lisp("(ash 10 1 1)"), "E1007");
+        assert_eq!(do_lisp("(ash a 1)"), "E1008");
+        assert_eq!(do_lisp("(ash 10 a)"), "E1008");
+        assert_eq!(do_lisp("(ash 10.5 1)"), "E1002");
+        assert_eq!(do_lisp("(ash 10 1.5)"), "E1002");
     }
     #[test]
     fn logand() {
-        assert_str!(do_lisp("(logand)"), "E1007");
-        assert_str!(do_lisp("(logand 10)"), "E1007");
-        assert_str!(do_lisp("(logand a 1)"), "E1008");
-        assert_str!(do_lisp("(logand 10 a)"), "E1008");
-        assert_str!(do_lisp("(logand 10.5 1)"), "E1002");
-        assert_str!(do_lisp("(logand 10 1.5)"), "E1002");
+        assert_eq!(do_lisp("(logand)"), "E1007");
+        assert_eq!(do_lisp("(logand 10)"), "E1007");
+        assert_eq!(do_lisp("(logand a 1)"), "E1008");
+        assert_eq!(do_lisp("(logand 10 a)"), "E1008");
+        assert_eq!(do_lisp("(logand 10.5 1)"), "E1002");
+        assert_eq!(do_lisp("(logand 10 1.5)"), "E1002");
     }
     #[test]
     fn logior() {
-        assert_str!(do_lisp("(logior)"), "E1007");
-        assert_str!(do_lisp("(logior 10)"), "E1007");
-        assert_str!(do_lisp("(logior a 1)"), "E1008");
-        assert_str!(do_lisp("(logior 10 a)"), "E1008");
-        assert_str!(do_lisp("(logior 10.5 1)"), "E1002");
-        assert_str!(do_lisp("(logior 10 1.5)"), "E1002");
+        assert_eq!(do_lisp("(logior)"), "E1007");
+        assert_eq!(do_lisp("(logior 10)"), "E1007");
+        assert_eq!(do_lisp("(logior a 1)"), "E1008");
+        assert_eq!(do_lisp("(logior 10 a)"), "E1008");
+        assert_eq!(do_lisp("(logior 10.5 1)"), "E1002");
+        assert_eq!(do_lisp("(logior 10 1.5)"), "E1002");
     }
     #[test]
     fn logxor() {
-        assert_str!(do_lisp("(logxor)"), "E1007");
-        assert_str!(do_lisp("(logxor 10)"), "E1007");
-        assert_str!(do_lisp("(logxor a 1)"), "E1008");
-        assert_str!(do_lisp("(logxor 10 a)"), "E1008");
-        assert_str!(do_lisp("(logxor 10.5 1)"), "E1002");
-        assert_str!(do_lisp("(logxor 10 1.5)"), "E1002");
+        assert_eq!(do_lisp("(logxor)"), "E1007");
+        assert_eq!(do_lisp("(logxor 10)"), "E1007");
+        assert_eq!(do_lisp("(logxor a 1)"), "E1008");
+        assert_eq!(do_lisp("(logxor 10 a)"), "E1008");
+        assert_eq!(do_lisp("(logxor 10.5 1)"), "E1002");
+        assert_eq!(do_lisp("(logxor 10 1.5)"), "E1002");
     }
     #[test]
     fn lognot() {
-        assert_str!(do_lisp("(lognot)"), "E1007");
-        assert_str!(do_lisp("(lognot 10 10)"), "E1007");
-        assert_str!(do_lisp("(lognot a)"), "E1008");
-        assert_str!(do_lisp("(lognot 1.5)"), "E1002");
+        assert_eq!(do_lisp("(lognot)"), "E1007");
+        assert_eq!(do_lisp("(lognot 10 10)"), "E1007");
+        assert_eq!(do_lisp("(lognot a)"), "E1008");
+        assert_eq!(do_lisp("(lognot 1.5)"), "E1002");
     }
     #[test]
     fn even() {
-        assert_str!(do_lisp("(even?)"), "E1007");
-        assert_str!(do_lisp("(even? 1 2)"), "E1007");
-        assert_str!(do_lisp("(even? 1/3)"), "E1002");
-        assert_str!(do_lisp("(even? 10.5)"), "E1002");
-        assert_str!(do_lisp("(even? a)"), "E1008");
+        assert_eq!(do_lisp("(even?)"), "E1007");
+        assert_eq!(do_lisp("(even? 1 2)"), "E1007");
+        assert_eq!(do_lisp("(even? 1/3)"), "E1002");
+        assert_eq!(do_lisp("(even? 10.5)"), "E1002");
+        assert_eq!(do_lisp("(even? a)"), "E1008");
     }
     #[test]
     fn odd() {
-        assert_str!(do_lisp("(odd?)"), "E1007");
-        assert_str!(do_lisp("(odd? 1 2)"), "E1007");
-        assert_str!(do_lisp("(odd? 1/3)"), "E1002");
-        assert_str!(do_lisp("(odd? 10.5)"), "E1002");
-        assert_str!(do_lisp("(odd? a)"), "E1008");
+        assert_eq!(do_lisp("(odd?)"), "E1007");
+        assert_eq!(do_lisp("(odd? 1 2)"), "E1007");
+        assert_eq!(do_lisp("(odd? 1/3)"), "E1002");
+        assert_eq!(do_lisp("(odd? 10.5)"), "E1002");
+        assert_eq!(do_lisp("(odd? a)"), "E1008");
     }
     #[test]
     fn zero() {
-        assert_str!(do_lisp("(zero?)"), "E1007");
-        assert_str!(do_lisp("(zero? 1 2)"), "E1007");
-        assert_str!(do_lisp("(zero? #f)"), "E1003");
-        assert_str!(do_lisp("(zero? a)"), "E1008");
+        assert_eq!(do_lisp("(zero?)"), "E1007");
+        assert_eq!(do_lisp("(zero? 1 2)"), "E1007");
+        assert_eq!(do_lisp("(zero? #f)"), "E1003");
+        assert_eq!(do_lisp("(zero? a)"), "E1008");
     }
     #[test]
     fn positive() {
-        assert_str!(do_lisp("(positive?)"), "E1007");
-        assert_str!(do_lisp("(positive? 1 2)"), "E1007");
-        assert_str!(do_lisp("(positive? #f)"), "E1003");
-        assert_str!(do_lisp("(positive? a)"), "E1008");
+        assert_eq!(do_lisp("(positive?)"), "E1007");
+        assert_eq!(do_lisp("(positive? 1 2)"), "E1007");
+        assert_eq!(do_lisp("(positive? #f)"), "E1003");
+        assert_eq!(do_lisp("(positive? a)"), "E1008");
     }
     #[test]
     fn negative() {
-        assert_str!(do_lisp("(negative?)"), "E1007");
-        assert_str!(do_lisp("(negative? 1 2)"), "E1007");
-        assert_str!(do_lisp("(negative? #f)"), "E1003");
-        assert_str!(do_lisp("(negative? a)"), "E1008");
+        assert_eq!(do_lisp("(negative?)"), "E1007");
+        assert_eq!(do_lisp("(negative? 1 2)"), "E1007");
+        assert_eq!(do_lisp("(negative? #f)"), "E1003");
+        assert_eq!(do_lisp("(negative? a)"), "E1008");
     }
     #[test]
     fn list_f() {
-        assert_str!(do_lisp("(list?)"), "E1007");
-        assert_str!(do_lisp("(list? (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(list? a)"), "E1008");
+        assert_eq!(do_lisp("(list?)"), "E1007");
+        assert_eq!(do_lisp("(list? (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(list? a)"), "E1008");
     }
     #[test]
     fn pair_f() {
-        assert_str!(do_lisp("(pair?)"), "E1007");
-        assert_str!(do_lisp("(pair? (cons 1 2)(cons 3 4))"), "E1007");
-        assert_str!(do_lisp("(pair? a)"), "E1008");
+        assert_eq!(do_lisp("(pair?)"), "E1007");
+        assert_eq!(do_lisp("(pair? (cons 1 2)(cons 3 4))"), "E1007");
+        assert_eq!(do_lisp("(pair? a)"), "E1008");
     }
     #[test]
     fn char_f() {
-        assert_str!(do_lisp("(char?)"), "E1007");
-        assert_str!(do_lisp("(char? #\\a #\\b)"), "E1007");
-        assert_str!(do_lisp("(char? a)"), "E1008");
+        assert_eq!(do_lisp("(char?)"), "E1007");
+        assert_eq!(do_lisp("(char? #\\a #\\b)"), "E1007");
+        assert_eq!(do_lisp("(char? a)"), "E1008");
     }
     #[test]
     fn string_f() {
-        assert_str!(do_lisp("(string?)"), "E1007");
-        assert_str!(do_lisp("(string? \"a\" \"b\")"), "E1007");
-        assert_str!(do_lisp("(string? a)"), "E1008");
+        assert_eq!(do_lisp("(string?)"), "E1007");
+        assert_eq!(do_lisp("(string? \"a\" \"b\")"), "E1007");
+        assert_eq!(do_lisp("(string? a)"), "E1008");
     }
     #[test]
     fn integer_f() {
-        assert_str!(do_lisp("(integer?)"), "E1007");
-        assert_str!(do_lisp("(integer? 10 20)"), "E1007");
-        assert_str!(do_lisp("(integer? a)"), "E1008");
+        assert_eq!(do_lisp("(integer?)"), "E1007");
+        assert_eq!(do_lisp("(integer? 10 20)"), "E1007");
+        assert_eq!(do_lisp("(integer? a)"), "E1008");
     }
     #[test]
     fn number_f() {
-        assert_str!(do_lisp("(number?)"), "E1007");
-        assert_str!(do_lisp("(number? 10 20)"), "E1007");
-        assert_str!(do_lisp("(number? a)"), "E1008");
+        assert_eq!(do_lisp("(number?)"), "E1007");
+        assert_eq!(do_lisp("(number? 10 20)"), "E1007");
+        assert_eq!(do_lisp("(number? a)"), "E1008");
     }
     #[test]
     fn procedure_f() {
-        assert_str!(do_lisp("(procedure?)"), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp("(procedure?)"), "E1007");
+        assert_eq!(
             do_lisp("(procedure? (lambda (n) n)(lambda (n) n))"),
             "E1007"
         );
-        assert_str!(do_lisp("(procedure? a)"), "E1008");
+        assert_eq!(do_lisp("(procedure? a)"), "E1008");
     }
     #[test]
     fn define() {
         let env = lisp::Environment::new();
-        assert_str!(do_lisp_env("(define)", &env), "E1007");
-        assert_str!(do_lisp_env("(define a)", &env), "E1007");
-        assert_str!(do_lisp_env("(define a 11 12)", &env), "E1007");
-        assert_str!(do_lisp_env("(define 1 10)", &env), "E1004");
-        assert_str!(do_lisp_env("(define (hoge a 1) (+ 100 a))", &env), "E1004");
-        assert_str!(do_lisp_env("(define (hoge 1 a) (+ 100 a))", &env), "E1004");
-        assert_str!(do_lisp_env("(define (100 a b) (+ 100 a))", &env), "E1004");
-        assert_str!(do_lisp_env("(define () (+ 100 a))", &env), "E1007");
+        assert_eq!(do_lisp_env("(define)", &env), "E1007");
+        assert_eq!(do_lisp_env("(define a)", &env), "E1007");
+        assert_eq!(do_lisp_env("(define a 11 12)", &env), "E1007");
+        assert_eq!(do_lisp_env("(define 1 10)", &env), "E1004");
+        assert_eq!(do_lisp_env("(define (hoge a 1) (+ 100 a))", &env), "E1004");
+        assert_eq!(do_lisp_env("(define (hoge 1 a) (+ 100 a))", &env), "E1004");
+        assert_eq!(do_lisp_env("(define (100 a b) (+ 100 a))", &env), "E1004");
+        assert_eq!(do_lisp_env("(define () (+ 100 a))", &env), "E1007");
 
-        assert_str!(do_lisp_env("(define a ga)", &env), "E1008");
+        assert_eq!(do_lisp_env("(define a ga)", &env), "E1008");
     }
     #[test]
     fn lambda() {
         let env = lisp::Environment::new();
-        assert_str!(do_lisp_env("(lambda)", &env), "E1007");
-        assert_str!(do_lisp_env("(lambda (a b))", &env), "E1007");
-        assert_str!(do_lisp_env("(lambda  a (+ a b))", &env), "E1005");
-        assert_str!(do_lisp_env("(lambda (a 1) (+ a 10))", &env), "E1004");
-        assert_str!(do_lisp_env("((list 1) 10)", &env), "E1006");
+        assert_eq!(do_lisp_env("(lambda)", &env), "E1007");
+        assert_eq!(do_lisp_env("(lambda (a b))", &env), "E1007");
+        assert_eq!(do_lisp_env("(lambda  a (+ a b))", &env), "E1005");
+        assert_eq!(do_lisp_env("(lambda (a 1) (+ a 10))", &env), "E1004");
+        assert_eq!(do_lisp_env("((list 1) 10)", &env), "E1006");
 
         do_lisp_env("(define hoge (lambda (a b) (+ a b)))", &env);
-        assert_str!(do_lisp_env("(hoge 10 ga)", &env), "E1008");
+        assert_eq!(do_lisp_env("(hoge 10 ga)", &env), "E1008");
 
         do_lisp_env("(define hoge (lambda (a b) (+ ga b)))", &env);
-        assert_str!(do_lisp_env("(hoge 10 20)", &env), "E1008");
+        assert_eq!(do_lisp_env("(hoge 10 20)", &env), "E1008");
     }
     #[test]
     fn if_f() {
-        assert_str!(do_lisp("(if (<= 1 6))"), "E1007");
-        assert_str!(do_lisp("(if (<= 1 6) a #\\b)"), "E1008");
-        assert_str!(do_lisp("(if (<= 9 6) #\\a b)"), "E1008");
-        assert_str!(do_lisp("(if 9 #\\a b)"), "E1001");
+        assert_eq!(do_lisp("(if (<= 1 6))"), "E1007");
+        assert_eq!(do_lisp("(if (<= 1 6) a #\\b)"), "E1008");
+        assert_eq!(do_lisp("(if (<= 9 6) #\\a b)"), "E1008");
+        assert_eq!(do_lisp("(if 9 #\\a b)"), "E1001");
     }
     #[test]
     fn cond() {
-        assert_str!(do_lisp("(cond)"), "E1007");
-        assert_str!(do_lisp("(cond 10)"), "E1005");
-        assert_str!(do_lisp("(cond (b 10))"), "E1008");
-        assert_str!(do_lisp("(cond ((= 10 10) b))"), "E1008");
-        assert_str!(do_lisp("(cond ())"), "E1012");
+        assert_eq!(do_lisp("(cond)"), "E1007");
+        assert_eq!(do_lisp("(cond 10)"), "E1005");
+        assert_eq!(do_lisp("(cond (b 10))"), "E1008");
+        assert_eq!(do_lisp("(cond ((= 10 10) b))"), "E1008");
+        assert_eq!(do_lisp("(cond ())"), "E1012");
     }
     #[test]
     fn eqv() {
-        assert_str!(do_lisp("(eqv?)"), "E1007");
-        assert_str!(do_lisp("(eqv? 10 10 10)"), "E1007");
-        assert_str!(do_lisp("(eq? 10 10 10)"), "E1007");
-        assert_str!(do_lisp("(eq? 10 a)"), "E1008");
-        assert_str!(do_lisp("(eq? a 10)"), "E1008");
+        assert_eq!(do_lisp("(eqv?)"), "E1007");
+        assert_eq!(do_lisp("(eqv? 10 10 10)"), "E1007");
+        assert_eq!(do_lisp("(eq? 10 10 10)"), "E1007");
+        assert_eq!(do_lisp("(eq? 10 a)"), "E1008");
+        assert_eq!(do_lisp("(eq? a 10)"), "E1008");
     }
     #[test]
     fn case() {
-        assert_str!(do_lisp("(case)"), "E1007");
-        assert_str!(do_lisp("(case 10 (hoge 20))"), "E1017");
-        assert_str!(do_lisp("(case 10 10)"), "E1005");
-        assert_str!(do_lisp("(case 10 (20))"), "E1017");
-        assert_str!(do_lisp("(case a)"), "E1008");
-        assert_str!(do_lisp("(case 10 ((10 20) a))"), "E1008");
-        assert_str!(do_lisp("(case 10 ((20 30) 1)(else a))"), "E1008");
+        assert_eq!(do_lisp("(case)"), "E1007");
+        assert_eq!(do_lisp("(case 10 (hoge 20))"), "E1017");
+        assert_eq!(do_lisp("(case 10 10)"), "E1005");
+        assert_eq!(do_lisp("(case 10 (20))"), "E1017");
+        assert_eq!(do_lisp("(case a)"), "E1008");
+        assert_eq!(do_lisp("(case 10 ((10 20) a))"), "E1008");
+        assert_eq!(do_lisp("(case 10 ((20 30) 1)(else a))"), "E1008");
     }
     #[test]
     fn apply() {
-        assert_str!(do_lisp("(apply)"), "E1007");
-        assert_str!(do_lisp("(apply -)"), "E1007");
-        assert_str!(do_lisp("(apply + (list 1 2)(lis 3 4))"), "E1007");
-        assert_str!(do_lisp("(apply + 10)"), "E1005");
-        assert_str!(do_lisp("(apply hoge (list 1 2))"), "E1008");
+        assert_eq!(do_lisp("(apply)"), "E1007");
+        assert_eq!(do_lisp("(apply -)"), "E1007");
+        assert_eq!(do_lisp("(apply + (list 1 2)(lis 3 4))"), "E1007");
+        assert_eq!(do_lisp("(apply + 10)"), "E1005");
+        assert_eq!(do_lisp("(apply hoge (list 1 2))"), "E1008");
     }
     #[test]
     fn identity() {
-        assert_str!(do_lisp("(identity)"), "E1007");
-        assert_str!(do_lisp("(identity 10 20)"), "E1007");
-        assert_str!(do_lisp("(identity a)"), "E1008");
+        assert_eq!(do_lisp("(identity)"), "E1007");
+        assert_eq!(do_lisp("(identity 10 20)"), "E1007");
+        assert_eq!(do_lisp("(identity a)"), "E1008");
     }
     #[test]
     fn modulo() {
-        assert_str!(do_lisp("(modulo 10)"), "E1007");
-        assert_str!(do_lisp("(modulo 10 0)"), "E1013");
-        assert_str!(do_lisp("(modulo 13 5.5)"), "E1002");
-        assert_str!(do_lisp("(modulo 10 a)"), "E1008");
+        assert_eq!(do_lisp("(modulo 10)"), "E1007");
+        assert_eq!(do_lisp("(modulo 10 0)"), "E1013");
+        assert_eq!(do_lisp("(modulo 13 5.5)"), "E1002");
+        assert_eq!(do_lisp("(modulo 10 a)"), "E1008");
     }
     #[test]
     fn quotient() {
-        assert_str!(do_lisp("(quotient 10)"), "E1007");
-        assert_str!(do_lisp("(quotient 10 0)"), "E1013");
-        assert_str!(do_lisp("(quotient 13 5.5)"), "E1002");
-        assert_str!(do_lisp("(quotient 10 a)"), "E1008");
+        assert_eq!(do_lisp("(quotient 10)"), "E1007");
+        assert_eq!(do_lisp("(quotient 10 0)"), "E1013");
+        assert_eq!(do_lisp("(quotient 13 5.5)"), "E1002");
+        assert_eq!(do_lisp("(quotient 10 a)"), "E1008");
     }
     #[test]
     fn expt() {
-        assert_str!(do_lisp("(expt 10)"), "E1007");
-        assert_str!(do_lisp("(expt a 2)"), "E1008");
-        assert_str!(do_lisp("(expt 10 #f)"), "E1003");
-        assert_str!(do_lisp("(expt 10.5 #f)"), "E1003");
-        assert_str!(do_lisp("(expt #t 10)"), "E1003");
+        assert_eq!(do_lisp("(expt 10)"), "E1007");
+        assert_eq!(do_lisp("(expt a 2)"), "E1008");
+        assert_eq!(do_lisp("(expt 10 #f)"), "E1003");
+        assert_eq!(do_lisp("(expt 10.5 #f)"), "E1003");
+        assert_eq!(do_lisp("(expt #t 10)"), "E1003");
     }
     #[test]
     fn and() {
-        assert_str!(do_lisp("(and (= 1 1))"), "E1007");
-        assert_str!(do_lisp("(and (= 1 1) 10)"), "E1001");
-        assert_str!(do_lisp("(and a (= 1 1))"), "E1008");
+        assert_eq!(do_lisp("(and (= 1 1))"), "E1007");
+        assert_eq!(do_lisp("(and (= 1 1) 10)"), "E1001");
+        assert_eq!(do_lisp("(and a (= 1 1))"), "E1008");
     }
     #[test]
     fn or() {
-        assert_str!(do_lisp("(or (= 1 1))"), "E1007");
-        assert_str!(do_lisp("(or (= 1 2) 10)"), "E1001");
-        assert_str!(do_lisp("(or a (= 1 2) 10)"), "E1008");
+        assert_eq!(do_lisp("(or (= 1 1))"), "E1007");
+        assert_eq!(do_lisp("(or (= 1 2) 10)"), "E1001");
+        assert_eq!(do_lisp("(or a (= 1 2) 10)"), "E1008");
     }
     #[test]
     fn not() {
-        assert_str!(do_lisp("(not)"), "E1007");
-        assert_str!(do_lisp("(not 10)"), "E1001");
-        assert_str!(do_lisp("(not a)"), "E1008");
+        assert_eq!(do_lisp("(not)"), "E1007");
+        assert_eq!(do_lisp("(not 10)"), "E1001");
+        assert_eq!(do_lisp("(not a)"), "E1008");
     }
     #[test]
     fn let_f() {
-        assert_str!(do_lisp("(let loop)"), "E1007");
-        assert_str!(do_lisp("(let ((i 0 10)) (+ i 10))"), "E1007");
-        assert_str!(do_lisp("(let ((100 10)) (+ i 10))"), "E1004");
-        assert_str!(do_lisp("(let ((i a)) (+ i 10))"), "E1008");
-        assert_str!(do_lisp("(let (10) (+ i 10))"), "E1005");
-        assert_str!(do_lisp("(let 100 (+ i 10))"), "E1005");
-        assert_str!(
+        assert_eq!(do_lisp("(let loop)"), "E1007");
+        assert_eq!(do_lisp("(let ((i 0 10)) (+ i 10))"), "E1007");
+        assert_eq!(do_lisp("(let ((100 10)) (+ i 10))"), "E1004");
+        assert_eq!(do_lisp("(let ((i a)) (+ i 10))"), "E1008");
+        assert_eq!(do_lisp("(let (10) (+ i 10))"), "E1005");
+        assert_eq!(do_lisp("(let 100 (+ i 10))"), "E1005");
+        assert_eq!(
             do_lisp("(let loop ((i 0)) (if (<= 10 i) i (loop (+ i 1)(+ i 1))))"),
             "E1007"
         );
@@ -1689,574 +1682,574 @@ mod error_tests {
     #[test]
     fn time_f() {
         let env = lisp::Environment::new();
-        assert_str!(do_lisp_env("(time)", &env), "E1007");
-        assert_str!(do_lisp_env("(time 10 10)", &env), "E1007");
-        assert_str!(do_lisp_env("(time c)", &env), "E1008");
+        assert_eq!(do_lisp_env("(time)", &env), "E1007");
+        assert_eq!(do_lisp_env("(time 10 10)", &env), "E1007");
+        assert_eq!(do_lisp_env("(time c)", &env), "E1008");
     }
     #[test]
     fn set_f() {
         let env = lisp::Environment::new();
-        assert_str!(do_lisp_env("(set!)", &env), "E1007");
-        assert_str!(do_lisp_env("(set! c)", &env), "E1007");
-        assert_str!(do_lisp_env("(set! 10 10)", &env), "E1004");
-        assert_str!(do_lisp_env("(set! c 10)", &env), "E1008");
+        assert_eq!(do_lisp_env("(set!)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set! c)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set! 10 10)", &env), "E1004");
+        assert_eq!(do_lisp_env("(set! c 10)", &env), "E1008");
     }
     #[test]
     fn list() {
-        assert_str!(do_lisp("(list c 10)"), "E1008");
+        assert_eq!(do_lisp("(list c 10)"), "E1008");
     }
     #[test]
     fn make_list() {
-        assert_str!(do_lisp("(make-list)"), "E1007");
-        assert_str!(do_lisp("(make-list 10)"), "E1007");
-        assert_str!(do_lisp("(make-list 10 0 1)"), "E1007");
-        assert_str!(do_lisp("(make-list #t 0)"), "E1002");
-        assert_str!(do_lisp("(make-list -1 0)"), "E1011");
-        assert_str!(do_lisp("(make-list 10 c)"), "E1008");
+        assert_eq!(do_lisp("(make-list)"), "E1007");
+        assert_eq!(do_lisp("(make-list 10)"), "E1007");
+        assert_eq!(do_lisp("(make-list 10 0 1)"), "E1007");
+        assert_eq!(do_lisp("(make-list #t 0)"), "E1002");
+        assert_eq!(do_lisp("(make-list -1 0)"), "E1011");
+        assert_eq!(do_lisp("(make-list 10 c)"), "E1008");
     }
     #[test]
     fn null_f() {
-        assert_str!(do_lisp("(null?)"), "E1007");
-        assert_str!(do_lisp("(null? (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(null? c)"), "E1008");
+        assert_eq!(do_lisp("(null?)"), "E1007");
+        assert_eq!(do_lisp("(null? (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(null? c)"), "E1008");
     }
     #[test]
     fn length() {
-        assert_str!(do_lisp("(length)"), "E1007");
-        assert_str!(do_lisp("(length (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(length (cons 1 2))"), "E1005");
-        assert_str!(do_lisp("(length a)"), "E1008");
+        assert_eq!(do_lisp("(length)"), "E1007");
+        assert_eq!(do_lisp("(length (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(length (cons 1 2))"), "E1005");
+        assert_eq!(do_lisp("(length a)"), "E1008");
     }
     #[test]
     fn car() {
-        assert_str!(do_lisp("(car)"), "E1007");
-        assert_str!(do_lisp("(car (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(car l)"), "E1008");
-        assert_str!(do_lisp("(car (list))"), "E1011");
-        assert_str!(do_lisp("(car 10)"), "E1005");
+        assert_eq!(do_lisp("(car)"), "E1007");
+        assert_eq!(do_lisp("(car (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(car l)"), "E1008");
+        assert_eq!(do_lisp("(car (list))"), "E1011");
+        assert_eq!(do_lisp("(car 10)"), "E1005");
     }
     #[test]
     fn cdr() {
-        assert_str!(do_lisp("(cdr)"), "E1007");
-        assert_str!(do_lisp("(cdr (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(cdr (list c))"), "E1008");
-        assert_str!(do_lisp("(cdr (list))"), "E1011");
-        assert_str!(do_lisp("(cdr 200)"), "E1005");
+        assert_eq!(do_lisp("(cdr)"), "E1007");
+        assert_eq!(do_lisp("(cdr (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(cdr (list c))"), "E1008");
+        assert_eq!(do_lisp("(cdr (list))"), "E1011");
+        assert_eq!(do_lisp("(cdr 200)"), "E1005");
     }
     #[test]
     fn cadr() {
-        assert_str!(do_lisp("(cadr)"), "E1007");
-        assert_str!(do_lisp("(cadr (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(cadr c)"), "E1008");
-        assert_str!(do_lisp("(cadr (list 1))"), "E1011");
-        assert_str!(do_lisp("(cadr 991)"), "E1005");
+        assert_eq!(do_lisp("(cadr)"), "E1007");
+        assert_eq!(do_lisp("(cadr (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(cadr c)"), "E1008");
+        assert_eq!(do_lisp("(cadr (list 1))"), "E1011");
+        assert_eq!(do_lisp("(cadr 991)"), "E1005");
     }
     #[test]
     fn cons() {
-        assert_str!(do_lisp("(cons)"), "E1007");
-        assert_str!(do_lisp("(cons (list 1)(list 2)(list 3))"), "E1007");
-        assert_str!(do_lisp("(cons a 10)"), "E1008");
+        assert_eq!(do_lisp("(cons)"), "E1007");
+        assert_eq!(do_lisp("(cons (list 1)(list 2)(list 3))"), "E1007");
+        assert_eq!(do_lisp("(cons a 10)"), "E1008");
     }
     #[test]
     fn append() {
-        assert_str!(do_lisp("(append)"), "E1007");
-        assert_str!(do_lisp("(append (list 1))"), "E1007");
-        assert_str!(do_lisp("(append (list 1) 105)"), "E1005");
-        assert_str!(do_lisp("(append (list 1) a)"), "E1008");
+        assert_eq!(do_lisp("(append)"), "E1007");
+        assert_eq!(do_lisp("(append (list 1))"), "E1007");
+        assert_eq!(do_lisp("(append (list 1) 105)"), "E1005");
+        assert_eq!(do_lisp("(append (list 1) a)"), "E1008");
     }
     #[test]
     fn take() {
-        assert_str!(do_lisp("(take)"), "E1007");
-        assert_str!(do_lisp("(take (list 10 20))"), "E1007");
-        assert_str!(do_lisp("(take (list 10 20) 1 2)"), "E1007");
-        assert_str!(do_lisp("(take 1 (list 1 2))"), "E1005");
-        assert_str!(do_lisp("(take (list 1 2) 10.5)"), "E1002");
-        assert_str!(do_lisp("(take (list 1 2) 3)"), "E1011");
-        assert_str!(do_lisp("(take (list 1 2) -1)"), "E1011");
-        assert_str!(do_lisp("(take a 1)"), "E1008");
+        assert_eq!(do_lisp("(take)"), "E1007");
+        assert_eq!(do_lisp("(take (list 10 20))"), "E1007");
+        assert_eq!(do_lisp("(take (list 10 20) 1 2)"), "E1007");
+        assert_eq!(do_lisp("(take 1 (list 1 2))"), "E1005");
+        assert_eq!(do_lisp("(take (list 1 2) 10.5)"), "E1002");
+        assert_eq!(do_lisp("(take (list 1 2) 3)"), "E1011");
+        assert_eq!(do_lisp("(take (list 1 2) -1)"), "E1011");
+        assert_eq!(do_lisp("(take a 1)"), "E1008");
     }
     #[test]
     fn drop() {
-        assert_str!(do_lisp("(drop)"), "E1007");
-        assert_str!(do_lisp("(drop (list 10 20))"), "E1007");
-        assert_str!(do_lisp("(drop (list 10 20) 1 2)"), "E1007");
-        assert_str!(do_lisp("(drop 1 (list 1 2))"), "E1005");
-        assert_str!(do_lisp("(drop (list 1 2) 10.5)"), "E1002");
-        assert_str!(do_lisp("(drop (list 1 2) 3)"), "E1011");
-        assert_str!(do_lisp("(drop (list 1 2) -1)"), "E1011");
-        assert_str!(do_lisp("(drop a 1)"), "E1008");
+        assert_eq!(do_lisp("(drop)"), "E1007");
+        assert_eq!(do_lisp("(drop (list 10 20))"), "E1007");
+        assert_eq!(do_lisp("(drop (list 10 20) 1 2)"), "E1007");
+        assert_eq!(do_lisp("(drop 1 (list 1 2))"), "E1005");
+        assert_eq!(do_lisp("(drop (list 1 2) 10.5)"), "E1002");
+        assert_eq!(do_lisp("(drop (list 1 2) 3)"), "E1011");
+        assert_eq!(do_lisp("(drop (list 1 2) -1)"), "E1011");
+        assert_eq!(do_lisp("(drop a 1)"), "E1008");
     }
     #[test]
     fn delete() {
-        assert_str!(do_lisp("(delete)"), "E1007");
-        assert_str!(do_lisp("(delete 10)"), "E1007");
-        assert_str!(do_lisp("(delete 10 (list 10 20) 3)"), "E1007");
-        assert_str!(do_lisp("(delete 10 20)"), "E1005");
-        assert_str!(do_lisp("(delete 10 a)"), "E1008");
+        assert_eq!(do_lisp("(delete)"), "E1007");
+        assert_eq!(do_lisp("(delete 10)"), "E1007");
+        assert_eq!(do_lisp("(delete 10 (list 10 20) 3)"), "E1007");
+        assert_eq!(do_lisp("(delete 10 20)"), "E1005");
+        assert_eq!(do_lisp("(delete 10 a)"), "E1008");
     }
     #[test]
     fn last() {
-        assert_str!(do_lisp("(last)"), "E1007");
-        assert_str!(do_lisp("(last (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(last (list))"), "E1011");
-        assert_str!(do_lisp("(last 29)"), "E1005");
-        assert_str!(do_lisp("(last a)"), "E1008");
+        assert_eq!(do_lisp("(last)"), "E1007");
+        assert_eq!(do_lisp("(last (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(last (list))"), "E1011");
+        assert_eq!(do_lisp("(last 29)"), "E1005");
+        assert_eq!(do_lisp("(last a)"), "E1008");
     }
     #[test]
     fn reverse() {
-        assert_str!(do_lisp("(reverse)"), "E1007");
-        assert_str!(do_lisp("(reverse (list 1)(list 2))"), "E1007");
-        assert_str!(do_lisp("(reverse 29)"), "E1005");
-        assert_str!(do_lisp("(reverse a)"), "E1008");
+        assert_eq!(do_lisp("(reverse)"), "E1007");
+        assert_eq!(do_lisp("(reverse (list 1)(list 2))"), "E1007");
+        assert_eq!(do_lisp("(reverse 29)"), "E1005");
+        assert_eq!(do_lisp("(reverse a)"), "E1008");
     }
     #[test]
     fn iota() {
-        assert_str!(do_lisp("(iota)"), "E1007");
-        assert_str!(do_lisp("(iota 1 2 3 4)"), "E1007");
-        assert_str!(do_lisp("(iota 1.5 2)"), "E1002");
-        assert_str!(do_lisp("(iota 1 10.5)"), "E1002");
-        assert_str!(do_lisp("(iota 10 1 10.5)"), "E1002");
-        assert_str!(do_lisp("(iota a)"), "E1008");
+        assert_eq!(do_lisp("(iota)"), "E1007");
+        assert_eq!(do_lisp("(iota 1 2 3 4)"), "E1007");
+        assert_eq!(do_lisp("(iota 1.5 2)"), "E1002");
+        assert_eq!(do_lisp("(iota 1 10.5)"), "E1002");
+        assert_eq!(do_lisp("(iota 10 1 10.5)"), "E1002");
+        assert_eq!(do_lisp("(iota a)"), "E1008");
     }
     #[test]
     fn map() {
-        assert_str!(do_lisp("(map)"), "E1007");
-        assert_str!(do_lisp("(map (lambda (n) n))"), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp("(map)"), "E1007");
+        assert_eq!(do_lisp("(map (lambda (n) n))"), "E1007");
+        assert_eq!(
             do_lisp("(map (lambda (a b) (* 10 a)) (list 1 2 3))"),
             "E1007"
         );
-        assert_str!(do_lisp("(map 1 2 3)"), "E1007");
-        assert_str!(do_lisp("(map (iota 10) (lambda (n) n))"), "E1006");
-        assert_str!(do_lisp("(map  (lambda (n) n) 10)"), "E1005");
+        assert_eq!(do_lisp("(map 1 2 3)"), "E1007");
+        assert_eq!(do_lisp("(map (iota 10) (lambda (n) n))"), "E1006");
+        assert_eq!(do_lisp("(map  (lambda (n) n) 10)"), "E1005");
     }
     #[test]
     fn filter() {
-        assert_str!(do_lisp("(filter)"), "E1007");
-        assert_str!(do_lisp("(filter (lambda (n) n))"), "E1007");
-        assert_str!(do_lisp("(filter 1 2 3)"), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp("(filter)"), "E1007");
+        assert_eq!(do_lisp("(filter (lambda (n) n))"), "E1007");
+        assert_eq!(do_lisp("(filter 1 2 3)"), "E1007");
+        assert_eq!(
             do_lisp("(filter (lambda (a b) (= 0 a))(iota 10 1))"),
             "E1007"
         );
-        assert_str!(do_lisp("(filter (iota 10) (lambda (n) n))"), "E1006");
-        assert_str!(do_lisp("(filter (lambda (n) n) 10)"), "E1005");
-        assert_str!(do_lisp("(filter (lambda (n) n) (iota 4))"), "E1001");
+        assert_eq!(do_lisp("(filter (iota 10) (lambda (n) n))"), "E1006");
+        assert_eq!(do_lisp("(filter (lambda (n) n) 10)"), "E1005");
+        assert_eq!(do_lisp("(filter (lambda (n) n) (iota 4))"), "E1001");
     }
     #[test]
     fn reduce() {
-        assert_str!(do_lisp("(reduce)"), "E1007");
-        assert_str!(do_lisp("(reduce (lambda (n) n))"), "E1007");
-        assert_str!(do_lisp("(reduce 1 2 3 4)"), "E1007");
-        assert_str!(do_lisp("(reduce 0 (list) (list))"), "E1006");
-        assert_str!(do_lisp("(reduce (lambda (n) n) 10 10)"), "E1005");
-        assert_str!(do_lisp("(reduce (lambda (n) n) 0 (iota 4))"), "E1007");
+        assert_eq!(do_lisp("(reduce)"), "E1007");
+        assert_eq!(do_lisp("(reduce (lambda (n) n))"), "E1007");
+        assert_eq!(do_lisp("(reduce 1 2 3 4)"), "E1007");
+        assert_eq!(do_lisp("(reduce 0 (list) (list))"), "E1006");
+        assert_eq!(do_lisp("(reduce (lambda (n) n) 10 10)"), "E1005");
+        assert_eq!(do_lisp("(reduce (lambda (n) n) 0 (iota 4))"), "E1007");
     }
     #[test]
     fn for_each() {
-        assert_str!(do_lisp("(for-each)"), "E1007");
-        assert_str!(do_lisp("(for-each (lambda (n) n))"), "E1007");
-        assert_str!(do_lisp("(for-each 1 2 3)"), "E1007");
-        assert_str!(do_lisp("(for-each (list) (list))"), "E1006");
-        assert_str!(do_lisp("(for-each (lambda (n) n) 10)"), "E1005");
+        assert_eq!(do_lisp("(for-each)"), "E1007");
+        assert_eq!(do_lisp("(for-each (lambda (n) n))"), "E1007");
+        assert_eq!(do_lisp("(for-each 1 2 3)"), "E1007");
+        assert_eq!(do_lisp("(for-each (list) (list))"), "E1006");
+        assert_eq!(do_lisp("(for-each (lambda (n) n) 10)"), "E1005");
     }
     #[test]
     fn list_ref() {
-        assert_str!(do_lisp("(list-ref)"), "E1007");
-        assert_str!(do_lisp("(list-ref (iota 10))"), "E1007");
-        assert_str!(do_lisp("(list-ref (iota 10) 1 2)"), "E1007");
-        assert_str!(do_lisp("(list-ref 10 -1)"), "E1005");
-        assert_str!(do_lisp("(list-ref (iota 10) #t)"), "E1002");
+        assert_eq!(do_lisp("(list-ref)"), "E1007");
+        assert_eq!(do_lisp("(list-ref (iota 10))"), "E1007");
+        assert_eq!(do_lisp("(list-ref (iota 10) 1 2)"), "E1007");
+        assert_eq!(do_lisp("(list-ref 10 -1)"), "E1005");
+        assert_eq!(do_lisp("(list-ref (iota 10) #t)"), "E1002");
 
-        assert_str!(do_lisp("(list-ref a #t)"), "E1008");
-        assert_str!(do_lisp("(list-ref (iota 10) a)"), "E1008");
+        assert_eq!(do_lisp("(list-ref a #t)"), "E1008");
+        assert_eq!(do_lisp("(list-ref (iota 10) a)"), "E1008");
 
-        assert_str!(do_lisp("(list-ref (iota 10) -1)"), "E1011");
-        assert_str!(do_lisp("(list-ref (iota 10) 10)"), "E1011");
+        assert_eq!(do_lisp("(list-ref (iota 10) -1)"), "E1011");
+        assert_eq!(do_lisp("(list-ref (iota 10) 10)"), "E1011");
     }
     #[test]
     fn sqrt() {
-        assert_str!(do_lisp("(sqrt)"), "E1007");
-        assert_str!(do_lisp("(sqrt 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(sqrt #t)"), "E1003");
-        assert_str!(do_lisp("(sqrt a)"), "E1008");
+        assert_eq!(do_lisp("(sqrt)"), "E1007");
+        assert_eq!(do_lisp("(sqrt 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(sqrt #t)"), "E1003");
+        assert_eq!(do_lisp("(sqrt a)"), "E1008");
     }
     #[test]
     fn sin() {
-        assert_str!(do_lisp("(sin)"), "E1007");
-        assert_str!(do_lisp("(sin 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(sin #t)"), "E1003");
-        assert_str!(do_lisp("(sin a)"), "E1008");
+        assert_eq!(do_lisp("(sin)"), "E1007");
+        assert_eq!(do_lisp("(sin 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(sin #t)"), "E1003");
+        assert_eq!(do_lisp("(sin a)"), "E1008");
     }
     #[test]
     fn cos() {
-        assert_str!(do_lisp("(cos)"), "E1007");
-        assert_str!(do_lisp("(cos 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(cos #t)"), "E1003");
-        assert_str!(do_lisp("(cos a)"), "E1008");
+        assert_eq!(do_lisp("(cos)"), "E1007");
+        assert_eq!(do_lisp("(cos 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(cos #t)"), "E1003");
+        assert_eq!(do_lisp("(cos a)"), "E1008");
     }
     #[test]
     fn tan() {
-        assert_str!(do_lisp("(tan)"), "E1007");
-        assert_str!(do_lisp("(tan 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(tan #t)"), "E1003");
-        assert_str!(do_lisp("(tan a)"), "E1008");
+        assert_eq!(do_lisp("(tan)"), "E1007");
+        assert_eq!(do_lisp("(tan 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(tan #t)"), "E1003");
+        assert_eq!(do_lisp("(tan a)"), "E1008");
     }
     #[test]
     fn asin() {
-        assert_str!(do_lisp("(asin)"), "E1007");
-        assert_str!(do_lisp("(asin 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(asin #t)"), "E1003");
-        assert_str!(do_lisp("(asin a)"), "E1008");
+        assert_eq!(do_lisp("(asin)"), "E1007");
+        assert_eq!(do_lisp("(asin 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(asin #t)"), "E1003");
+        assert_eq!(do_lisp("(asin a)"), "E1008");
     }
     #[test]
     fn acos() {
-        assert_str!(do_lisp("(acos)"), "E1007");
-        assert_str!(do_lisp("(acos 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(acos #t)"), "E1003");
-        assert_str!(do_lisp("(acos a)"), "E1008");
+        assert_eq!(do_lisp("(acos)"), "E1007");
+        assert_eq!(do_lisp("(acos 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(acos #t)"), "E1003");
+        assert_eq!(do_lisp("(acos a)"), "E1008");
     }
     #[test]
     fn atan() {
-        assert_str!(do_lisp("(atan)"), "E1007");
-        assert_str!(do_lisp("(atan 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(atan #t)"), "E1003");
-        assert_str!(do_lisp("(atan a)"), "E1008");
+        assert_eq!(do_lisp("(atan)"), "E1007");
+        assert_eq!(do_lisp("(atan 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(atan #t)"), "E1003");
+        assert_eq!(do_lisp("(atan a)"), "E1008");
     }
     #[test]
     fn exp() {
-        assert_str!(do_lisp("(exp)"), "E1007");
-        assert_str!(do_lisp("(exp 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(exp #t)"), "E1003");
-        assert_str!(do_lisp("(exp a)"), "E1008");
+        assert_eq!(do_lisp("(exp)"), "E1007");
+        assert_eq!(do_lisp("(exp 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(exp #t)"), "E1003");
+        assert_eq!(do_lisp("(exp a)"), "E1008");
     }
     #[test]
     fn log() {
-        assert_str!(do_lisp("(log)"), "E1007");
-        assert_str!(do_lisp("(log 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(log #t)"), "E1003");
-        assert_str!(do_lisp("(log a)"), "E1008");
+        assert_eq!(do_lisp("(log)"), "E1007");
+        assert_eq!(do_lisp("(log 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(log #t)"), "E1003");
+        assert_eq!(do_lisp("(log a)"), "E1008");
     }
     #[test]
     fn truncate() {
-        assert_str!(do_lisp("(truncate)"), "E1007");
-        assert_str!(do_lisp("(truncate 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(truncate #t)"), "E1003");
-        assert_str!(do_lisp("(truncate a)"), "E1008");
+        assert_eq!(do_lisp("(truncate)"), "E1007");
+        assert_eq!(do_lisp("(truncate 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(truncate #t)"), "E1003");
+        assert_eq!(do_lisp("(truncate a)"), "E1008");
     }
     #[test]
     fn floor() {
-        assert_str!(do_lisp("(floor)"), "E1007");
-        assert_str!(do_lisp("(floor 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(floor #t)"), "E1003");
-        assert_str!(do_lisp("(floor a)"), "E1008");
+        assert_eq!(do_lisp("(floor)"), "E1007");
+        assert_eq!(do_lisp("(floor 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(floor #t)"), "E1003");
+        assert_eq!(do_lisp("(floor a)"), "E1008");
     }
     #[test]
     fn ceiling() {
-        assert_str!(do_lisp("(ceiling)"), "E1007");
-        assert_str!(do_lisp("(ceiling 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(ceiling #t)"), "E1003");
-        assert_str!(do_lisp("(ceiling a)"), "E1008");
+        assert_eq!(do_lisp("(ceiling)"), "E1007");
+        assert_eq!(do_lisp("(ceiling 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(ceiling #t)"), "E1003");
+        assert_eq!(do_lisp("(ceiling a)"), "E1008");
     }
     #[test]
     fn round() {
-        assert_str!(do_lisp("(round)"), "E1007");
-        assert_str!(do_lisp("(round 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(round #t)"), "E1003");
-        assert_str!(do_lisp("(round a)"), "E1008");
+        assert_eq!(do_lisp("(round)"), "E1007");
+        assert_eq!(do_lisp("(round 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(round #t)"), "E1003");
+        assert_eq!(do_lisp("(round a)"), "E1008");
     }
     #[test]
     fn abs() {
-        assert_str!(do_lisp("(abs)"), "E1007");
-        assert_str!(do_lisp("(abs 10 2.5)"), "E1007");
-        assert_str!(do_lisp("(abs #t)"), "E1003");
-        assert_str!(do_lisp("(abs a)"), "E1008");
+        assert_eq!(do_lisp("(abs)"), "E1007");
+        assert_eq!(do_lisp("(abs 10 2.5)"), "E1007");
+        assert_eq!(do_lisp("(abs #t)"), "E1003");
+        assert_eq!(do_lisp("(abs a)"), "E1008");
     }
     #[test]
     fn rand_integer() {
-        assert_str!(do_lisp("(rand-integer 10)"), "E1007");
+        assert_eq!(do_lisp("(rand-integer 10)"), "E1007");
     }
     #[test]
     fn rand_list() {
-        assert_str!(do_lisp("(rand-list)"), "E1007");
-        assert_str!(do_lisp("(rand-list 1 2)"), "E1007");
-        assert_str!(do_lisp("(rand-list 10.5)"), "E1002");
+        assert_eq!(do_lisp("(rand-list)"), "E1007");
+        assert_eq!(do_lisp("(rand-list 1 2)"), "E1007");
+        assert_eq!(do_lisp("(rand-list 10.5)"), "E1002");
     }
     #[test]
     fn load_file() {
-        assert_str!(do_lisp("(load-file)"), "E1007");
-        assert_str!(do_lisp("(load-file 1 2)"), "E1007");
-        assert_str!(do_lisp("(load-file hoge)"), "E1008");
-        assert_str!(do_lisp("(load-file #t)"), "E1015");
-        assert_str!(do_lisp("(load-file \"/etc/test.scm\")"), "E1014");
-        assert_str!(do_lisp("(load-file \"/tmp\")"), "E1016");
-        assert_str!(do_lisp("(load-file \"/bin/cp\")"), "E9999");
+        assert_eq!(do_lisp("(load-file)"), "E1007");
+        assert_eq!(do_lisp("(load-file 1 2)"), "E1007");
+        assert_eq!(do_lisp("(load-file hoge)"), "E1008");
+        assert_eq!(do_lisp("(load-file #t)"), "E1015");
+        assert_eq!(do_lisp("(load-file \"/etc/test.scm\")"), "E1014");
+        assert_eq!(do_lisp("(load-file \"/tmp\")"), "E1016");
+        assert_eq!(do_lisp("(load-file \"/bin/cp\")"), "E9999");
     }
     #[test]
     fn delay_force() {
-        assert_str!(do_lisp("(delay)"), "E1007");
-        assert_str!(do_lisp("(delay 1 2)"), "E1007");
-        assert_str!(do_lisp("(force)"), "E1007");
-        assert_str!(do_lisp("(force 1 2)"), "E1007");
-        assert_str!(do_lisp("(force hoge)"), "E1008");
+        assert_eq!(do_lisp("(delay)"), "E1007");
+        assert_eq!(do_lisp("(delay 1 2)"), "E1007");
+        assert_eq!(do_lisp("(force)"), "E1007");
+        assert_eq!(do_lisp("(force 1 2)"), "E1007");
+        assert_eq!(do_lisp("(force hoge)"), "E1008");
     }
     #[test]
     fn display() {
-        assert_str!(do_lisp("(display)"), "E1007");
-        assert_str!(do_lisp("(display a)"), "E1008");
+        assert_eq!(do_lisp("(display)"), "E1007");
+        assert_eq!(do_lisp("(display a)"), "E1008");
     }
     #[test]
     fn newline() {
-        assert_str!(do_lisp("(newline 123)"), "E1007");
+        assert_eq!(do_lisp("(newline 123)"), "E1007");
     }
     #[test]
     fn begin() {
-        assert_str!(do_lisp("(begin)"), "E1007");
-        assert_str!(do_lisp("(begin a)"), "E1008");
+        assert_eq!(do_lisp("(begin)"), "E1007");
+        assert_eq!(do_lisp("(begin a)"), "E1008");
     }
     #[test]
     fn sequence() {
-        assert_str!(
+        assert_eq!(
             do_lisp("(let ((i 0)) (define i 100) (set! i (+ i b)) i)"),
             "E1008"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp("((lambda (a) (define i 100) (set! i (+ i b)) i)10)"),
             "E1008"
         );
     }
     #[test]
     fn format_f() {
-        assert_str!(do_lisp("(format)"), "E1007");
-        assert_str!(do_lisp("(format \"~B\")"), "E1007");
-        assert_str!(do_lisp("(format \"~B\" 10 12)"), "E1007");
-        assert_str!(do_lisp("(format 10 12)"), "E1015");
-        assert_str!(do_lisp("(format \"~A\" #f)"), "E1002");
-        assert_str!(do_lisp("(format \"~A\" 10)"), "E1018");
+        assert_eq!(do_lisp("(format)"), "E1007");
+        assert_eq!(do_lisp("(format \"~B\")"), "E1007");
+        assert_eq!(do_lisp("(format \"~B\" 10 12)"), "E1007");
+        assert_eq!(do_lisp("(format 10 12)"), "E1015");
+        assert_eq!(do_lisp("(format \"~A\" #f)"), "E1002");
+        assert_eq!(do_lisp("(format \"~A\" 10)"), "E1018");
     }
     #[test]
     fn force_stop() {
-        assert_str!(do_lisp("(force-stop 10)"), "E1008");
+        assert_eq!(do_lisp("(force-stop 10)"), "E1008");
     }
     #[test]
     fn set_tail_recursion() {
-        assert_str!(do_lisp("(tail-recursion-off 20)"), "E1008");
-        assert_str!(do_lisp("(tail-recursion-on 30)"), "E1008");
+        assert_eq!(do_lisp("(tail-recursion-off 20)"), "E1008");
+        assert_eq!(do_lisp("(tail-recursion-on 30)"), "E1008");
     }
     #[test]
     fn string_eq() {
-        assert_str!(do_lisp("(string=?)"), "E1007");
-        assert_str!(do_lisp("(string=? \"abc\")"), "E1007");
-        assert_str!(do_lisp("(string=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
-        assert_str!(do_lisp("(string=? \"abc\" 10)"), "E1015");
-        assert_str!(do_lisp("(string=? 10 \"abc\")"), "E1015");
-        assert_str!(do_lisp("(string=? \"abc\" a)"), "E1008");
+        assert_eq!(do_lisp("(string=?)"), "E1007");
+        assert_eq!(do_lisp("(string=? \"abc\")"), "E1007");
+        assert_eq!(do_lisp("(string=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
+        assert_eq!(do_lisp("(string=? \"abc\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string=? 10 \"abc\")"), "E1015");
+        assert_eq!(do_lisp("(string=? \"abc\" a)"), "E1008");
     }
     #[test]
     fn string_less() {
-        assert_str!(do_lisp("(string<?)"), "E1007");
-        assert_str!(do_lisp("(string<? \"abc\")"), "E1007");
-        assert_str!(do_lisp("(string<? \"abc\" \"ABC\" \"DEF\")"), "E1007");
-        assert_str!(do_lisp("(string<? \"abc\" 10)"), "E1015");
-        assert_str!(do_lisp("(string<? 10 \"abc\")"), "E1015");
-        assert_str!(do_lisp("(string<? \"abc\" a)"), "E1008");
+        assert_eq!(do_lisp("(string<?)"), "E1007");
+        assert_eq!(do_lisp("(string<? \"abc\")"), "E1007");
+        assert_eq!(do_lisp("(string<? \"abc\" \"ABC\" \"DEF\")"), "E1007");
+        assert_eq!(do_lisp("(string<? \"abc\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string<? 10 \"abc\")"), "E1015");
+        assert_eq!(do_lisp("(string<? \"abc\" a)"), "E1008");
     }
     #[test]
     fn string_than() {
-        assert_str!(do_lisp("(string>?)"), "E1007");
-        assert_str!(do_lisp("(string>? \"abc\")"), "E1007");
-        assert_str!(do_lisp("(string>? \"abc\" \"ABC\" \"DEF\")"), "E1007");
-        assert_str!(do_lisp("(string>? \"abc\" 10)"), "E1015");
-        assert_str!(do_lisp("(string>? 10 \"abc\")"), "E1015");
-        assert_str!(do_lisp("(string>? \"abc\" a)"), "E1008");
+        assert_eq!(do_lisp("(string>?)"), "E1007");
+        assert_eq!(do_lisp("(string>? \"abc\")"), "E1007");
+        assert_eq!(do_lisp("(string>? \"abc\" \"ABC\" \"DEF\")"), "E1007");
+        assert_eq!(do_lisp("(string>? \"abc\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string>? 10 \"abc\")"), "E1015");
+        assert_eq!(do_lisp("(string>? \"abc\" a)"), "E1008");
     }
     #[test]
     fn string_le() {
-        assert_str!(do_lisp("(string<=?)"), "E1007");
-        assert_str!(do_lisp("(string<=? \"abc\")"), "E1007");
-        assert_str!(do_lisp("(string<=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
-        assert_str!(do_lisp("(string<=? \"abc\" 10)"), "E1015");
-        assert_str!(do_lisp("(string<=? 10 \"abc\")"), "E1015");
-        assert_str!(do_lisp("(string<=? \"abc\" a)"), "E1008");
+        assert_eq!(do_lisp("(string<=?)"), "E1007");
+        assert_eq!(do_lisp("(string<=? \"abc\")"), "E1007");
+        assert_eq!(do_lisp("(string<=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
+        assert_eq!(do_lisp("(string<=? \"abc\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string<=? 10 \"abc\")"), "E1015");
+        assert_eq!(do_lisp("(string<=? \"abc\" a)"), "E1008");
     }
     #[test]
     fn string_ge() {
-        assert_str!(do_lisp("(string>=?)"), "E1007");
-        assert_str!(do_lisp("(string>=? \"abc\")"), "E1007");
-        assert_str!(do_lisp("(string>=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
-        assert_str!(do_lisp("(string>=? \"abc\" 10)"), "E1015");
-        assert_str!(do_lisp("(string>=? 10 \"abc\")"), "E1015");
-        assert_str!(do_lisp("(string>=? \"abc\" a)"), "E1008");
+        assert_eq!(do_lisp("(string>=?)"), "E1007");
+        assert_eq!(do_lisp("(string>=? \"abc\")"), "E1007");
+        assert_eq!(do_lisp("(string>=? \"abc\" \"ABC\" \"DEF\")"), "E1007");
+        assert_eq!(do_lisp("(string>=? \"abc\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string>=? 10 \"abc\")"), "E1015");
+        assert_eq!(do_lisp("(string>=? \"abc\" a)"), "E1008");
     }
     #[test]
     fn char_eq() {
-        assert_str!(do_lisp("(char=?)"), "E1007");
-        assert_str!(do_lisp("(char=? #\\a)"), "E1007");
-        assert_str!(do_lisp("(char=? #\\a #\\b #\\c)"), "E1007");
-        assert_str!(do_lisp("(char=? #\\a 10)"), "E1019");
-        assert_str!(do_lisp("(char=? 10 #\\a)"), "E1019");
-        assert_str!(do_lisp("(char=? #\\a a)"), "E1008");
+        assert_eq!(do_lisp("(char=?)"), "E1007");
+        assert_eq!(do_lisp("(char=? #\\a)"), "E1007");
+        assert_eq!(do_lisp("(char=? #\\a #\\b #\\c)"), "E1007");
+        assert_eq!(do_lisp("(char=? #\\a 10)"), "E1019");
+        assert_eq!(do_lisp("(char=? 10 #\\a)"), "E1019");
+        assert_eq!(do_lisp("(char=? #\\a a)"), "E1008");
     }
     #[test]
     fn char_less() {
-        assert_str!(do_lisp("(char<?)"), "E1007");
-        assert_str!(do_lisp("(char<? #\\a)"), "E1007");
-        assert_str!(do_lisp("(char<? #\\a #\\b #\\c)"), "E1007");
-        assert_str!(do_lisp("(char<? #\\a 10)"), "E1019");
-        assert_str!(do_lisp("(char<? 10 #\\a)"), "E1019");
-        assert_str!(do_lisp("(char<? #\\a a)"), "E1008");
+        assert_eq!(do_lisp("(char<?)"), "E1007");
+        assert_eq!(do_lisp("(char<? #\\a)"), "E1007");
+        assert_eq!(do_lisp("(char<? #\\a #\\b #\\c)"), "E1007");
+        assert_eq!(do_lisp("(char<? #\\a 10)"), "E1019");
+        assert_eq!(do_lisp("(char<? 10 #\\a)"), "E1019");
+        assert_eq!(do_lisp("(char<? #\\a a)"), "E1008");
     }
     #[test]
     fn char_than() {
-        assert_str!(do_lisp("(char>?)"), "E1007");
-        assert_str!(do_lisp("(char>? #\\a)"), "E1007");
-        assert_str!(do_lisp("(char>? #\\a #\\b #\\c)"), "E1007");
-        assert_str!(do_lisp("(char>? #\\a 10)"), "E1019");
-        assert_str!(do_lisp("(char>? 10 #\\a)"), "E1019");
-        assert_str!(do_lisp("(char>? #\\a a)"), "E1008");
+        assert_eq!(do_lisp("(char>?)"), "E1007");
+        assert_eq!(do_lisp("(char>? #\\a)"), "E1007");
+        assert_eq!(do_lisp("(char>? #\\a #\\b #\\c)"), "E1007");
+        assert_eq!(do_lisp("(char>? #\\a 10)"), "E1019");
+        assert_eq!(do_lisp("(char>? 10 #\\a)"), "E1019");
+        assert_eq!(do_lisp("(char>? #\\a a)"), "E1008");
     }
     #[test]
     fn char_le() {
-        assert_str!(do_lisp("(char<=?)"), "E1007");
-        assert_str!(do_lisp("(char<=? #\\a)"), "E1007");
-        assert_str!(do_lisp("(char<=? #\\a #\\b #\\c)"), "E1007");
-        assert_str!(do_lisp("(char<=? #\\a 10)"), "E1019");
-        assert_str!(do_lisp("(char<=? 10 #\\a)"), "E1019");
-        assert_str!(do_lisp("(char<=? #\\a a)"), "E1008");
+        assert_eq!(do_lisp("(char<=?)"), "E1007");
+        assert_eq!(do_lisp("(char<=? #\\a)"), "E1007");
+        assert_eq!(do_lisp("(char<=? #\\a #\\b #\\c)"), "E1007");
+        assert_eq!(do_lisp("(char<=? #\\a 10)"), "E1019");
+        assert_eq!(do_lisp("(char<=? 10 #\\a)"), "E1019");
+        assert_eq!(do_lisp("(char<=? #\\a a)"), "E1008");
     }
     #[test]
     fn char_ge() {
-        assert_str!(do_lisp("(char>=?)"), "E1007");
-        assert_str!(do_lisp("(char>=? #\\a)"), "E1007");
-        assert_str!(do_lisp("(char>=? #\\a #\\b #\\c)"), "E1007");
-        assert_str!(do_lisp("(char>=? #\\a 10)"), "E1019");
-        assert_str!(do_lisp("(char>=? 10 #\\a)"), "E1019");
-        assert_str!(do_lisp("(char>=? #\\a a)"), "E1008");
+        assert_eq!(do_lisp("(char>=?)"), "E1007");
+        assert_eq!(do_lisp("(char>=? #\\a)"), "E1007");
+        assert_eq!(do_lisp("(char>=? #\\a #\\b #\\c)"), "E1007");
+        assert_eq!(do_lisp("(char>=? #\\a 10)"), "E1019");
+        assert_eq!(do_lisp("(char>=? 10 #\\a)"), "E1019");
+        assert_eq!(do_lisp("(char>=? #\\a a)"), "E1008");
     }
     #[test]
     fn str_append() {
-        assert_str!(do_lisp("(string-append)"), "E1007");
-        assert_str!(do_lisp("(string-append \"a\")"), "E1007");
-        assert_str!(do_lisp("(string-append \"a\" 10)"), "E1015");
-        assert_str!(do_lisp("(string-append \"a\" a)"), "E1008");
+        assert_eq!(do_lisp("(string-append)"), "E1007");
+        assert_eq!(do_lisp("(string-append \"a\")"), "E1007");
+        assert_eq!(do_lisp("(string-append \"a\" 10)"), "E1015");
+        assert_eq!(do_lisp("(string-append \"a\" a)"), "E1008");
     }
     #[test]
     fn string_length() {
-        assert_str!(do_lisp("(string-length)"), "E1007");
-        assert_str!(do_lisp("(string-length \"1234\" \"12345\")"), "E1007");
-        assert_str!(do_lisp("(string-length 1000)"), "E1015");
+        assert_eq!(do_lisp("(string-length)"), "E1007");
+        assert_eq!(do_lisp("(string-length \"1234\" \"12345\")"), "E1007");
+        assert_eq!(do_lisp("(string-length 1000)"), "E1015");
     }
     #[test]
     fn string_size() {
-        assert_str!(do_lisp("(string-size)"), "E1007");
-        assert_str!(do_lisp("(string-size \"1234\" \"12345\")"), "E1007");
-        assert_str!(do_lisp("(string-size 1000)"), "E1015");
+        assert_eq!(do_lisp("(string-size)"), "E1007");
+        assert_eq!(do_lisp("(string-size \"1234\" \"12345\")"), "E1007");
+        assert_eq!(do_lisp("(string-size 1000)"), "E1015");
     }
     #[test]
     fn number_string() {
-        assert_str!(do_lisp("(number->string)"), "E1007");
-        assert_str!(do_lisp("(number->string 10 20)"), "E1007");
-        assert_str!(do_lisp("(number->string #f)"), "E1003");
-        assert_str!(do_lisp("(number->string a)"), "E1008");
+        assert_eq!(do_lisp("(number->string)"), "E1007");
+        assert_eq!(do_lisp("(number->string 10 20)"), "E1007");
+        assert_eq!(do_lisp("(number->string #f)"), "E1003");
+        assert_eq!(do_lisp("(number->string a)"), "E1008");
     }
     #[test]
     fn string_number() {
-        assert_str!(do_lisp("(string->number)"), "E1007");
-        assert_str!(do_lisp("(string->number \"123\" \"10.5\")"), "E1007");
-        assert_str!(do_lisp("(string->number 100)"), "E1015");
-        assert_str!(do_lisp("(string->number \"/1\")"), "E1003");
-        assert_str!(do_lisp("(string->number \"1/3/2\")"), "E1003");
-        assert_str!(do_lisp("(string->number \"1/0\")"), "E1013");
-        assert_str!(do_lisp("(string->number a)"), "E1008");
+        assert_eq!(do_lisp("(string->number)"), "E1007");
+        assert_eq!(do_lisp("(string->number \"123\" \"10.5\")"), "E1007");
+        assert_eq!(do_lisp("(string->number 100)"), "E1015");
+        assert_eq!(do_lisp("(string->number \"/1\")"), "E1003");
+        assert_eq!(do_lisp("(string->number \"1/3/2\")"), "E1003");
+        assert_eq!(do_lisp("(string->number \"1/0\")"), "E1013");
+        assert_eq!(do_lisp("(string->number a)"), "E1008");
     }
     #[test]
     fn list_string() {
-        assert_str!(do_lisp("(list->string)"), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp("(list->string)"), "E1007");
+        assert_eq!(
             do_lisp("(list->string (list #\\a #\\b)(list #\\a #\\b))"),
             "E1007"
         );
-        assert_str!(do_lisp("(list->string 10)"), "E1005");
-        assert_str!(do_lisp("(list->string (list #\\a 10))"), "E1019");
-        assert_str!(do_lisp("(list->string a)"), "E1008");
+        assert_eq!(do_lisp("(list->string 10)"), "E1005");
+        assert_eq!(do_lisp("(list->string (list #\\a 10))"), "E1019");
+        assert_eq!(do_lisp("(list->string a)"), "E1008");
     }
     #[test]
     fn substring() {
-        assert_str!(do_lisp("(substring)"), "E1007");
-        assert_str!(do_lisp("(substring \"1234567890\" 1)"), "E1007");
-        assert_str!(do_lisp("(substring \"1234567890\" 1 2 3)"), "E1007");
-        assert_str!(do_lisp("(substring  1 2 3)"), "E1015");
-        assert_str!(do_lisp("(substring \"1234567890\" #t 2)"), "E1002");
-        assert_str!(do_lisp("(substring \"1234567890\" 0 #t)"), "E1002");
-        assert_str!(do_lisp("(substring \"1234567890\" a 2)"), "E1008");
-        assert_str!(do_lisp("(substring \"1234567890\" 0 a)"), "E1008");
+        assert_eq!(do_lisp("(substring)"), "E1007");
+        assert_eq!(do_lisp("(substring \"1234567890\" 1)"), "E1007");
+        assert_eq!(do_lisp("(substring \"1234567890\" 1 2 3)"), "E1007");
+        assert_eq!(do_lisp("(substring  1 2 3)"), "E1015");
+        assert_eq!(do_lisp("(substring \"1234567890\" #t 2)"), "E1002");
+        assert_eq!(do_lisp("(substring \"1234567890\" 0 #t)"), "E1002");
+        assert_eq!(do_lisp("(substring \"1234567890\" a 2)"), "E1008");
+        assert_eq!(do_lisp("(substring \"1234567890\" 0 a)"), "E1008");
 
-        assert_str!(do_lisp("(substring \"1234567890\" -1 2)"), "E1021");
-        assert_str!(do_lisp("(substring \"1234567890\" 0 -2)"), "E1021");
-        assert_str!(do_lisp("(substring \"1234567890\" 0 11)"), "E1021");
-        assert_str!(do_lisp("(substring \"1234567890\" 6 5)"), "E1021");
+        assert_eq!(do_lisp("(substring \"1234567890\" -1 2)"), "E1021");
+        assert_eq!(do_lisp("(substring \"1234567890\" 0 -2)"), "E1021");
+        assert_eq!(do_lisp("(substring \"1234567890\" 0 11)"), "E1021");
+        assert_eq!(do_lisp("(substring \"1234567890\" 6 5)"), "E1021");
 
-        assert_str!(do_lisp("(substring \"山\" 0 2)"), "E1021");
+        assert_eq!(do_lisp("(substring \"山\" 0 2)"), "E1021");
     }
     #[test]
     fn symbol_string() {
-        assert_str!(do_lisp("(symbol->string)"), "E1007");
-        assert_str!(do_lisp("(symbol->string 'a 'b)"), "E1007");
-        assert_str!(do_lisp("(symbol->string #t)"), "E1004");
+        assert_eq!(do_lisp("(symbol->string)"), "E1007");
+        assert_eq!(do_lisp("(symbol->string 'a 'b)"), "E1007");
+        assert_eq!(do_lisp("(symbol->string #t)"), "E1004");
     }
     #[test]
     fn string_symbol() {
-        assert_str!(do_lisp("(string->symbol)"), "E1007");
-        assert_str!(do_lisp("(string->symbol \"abc\"  \"def\")"), "E1007");
-        assert_str!(do_lisp("(string->symbol #t)"), "E1015");
+        assert_eq!(do_lisp("(string->symbol)"), "E1007");
+        assert_eq!(do_lisp("(string->symbol \"abc\"  \"def\")"), "E1007");
+        assert_eq!(do_lisp("(string->symbol #t)"), "E1015");
     }
 
     #[test]
     fn string_list() {
-        assert_str!(do_lisp("(string->list)"), "E1007");
-        assert_str!(do_lisp("(string->list \"a\" \"b\")"), "E1007");
-        assert_str!(do_lisp("(string->list #\\a)"), "E1015");
-        assert_str!(do_lisp("(string->list a)"), "E1008");
+        assert_eq!(do_lisp("(string->list)"), "E1007");
+        assert_eq!(do_lisp("(string->list \"a\" \"b\")"), "E1007");
+        assert_eq!(do_lisp("(string->list #\\a)"), "E1015");
+        assert_eq!(do_lisp("(string->list a)"), "E1008");
     }
     #[test]
     fn make_string() {
-        assert_str!(do_lisp("(make-string)"), "E1007");
-        assert_str!(do_lisp("(make-string a)"), "E1007");
-        assert_str!(do_lisp("(make-string a a a)"), "E1007");
+        assert_eq!(do_lisp("(make-string)"), "E1007");
+        assert_eq!(do_lisp("(make-string a)"), "E1007");
+        assert_eq!(do_lisp("(make-string a a a)"), "E1007");
 
-        assert_str!(do_lisp("(make-string #t #\\a)"), "E1002");
-        assert_str!(do_lisp("(make-string -1 #\\a)"), "E1021");
-        assert_str!(do_lisp("(make-string 4 a)"), "E1008");
-        assert_str!(do_lisp("(make-string 4 #t)"), "E1019");
+        assert_eq!(do_lisp("(make-string #t #\\a)"), "E1002");
+        assert_eq!(do_lisp("(make-string -1 #\\a)"), "E1021");
+        assert_eq!(do_lisp("(make-string 4 a)"), "E1008");
+        assert_eq!(do_lisp("(make-string 4 #t)"), "E1019");
     }
     #[test]
     fn integer_char() {
-        assert_str!(do_lisp("(integer->char)"), "E1007");
-        assert_str!(do_lisp("(integer->char 23 665)"), "E1007");
-        assert_str!(do_lisp("(integer->char #\\a)"), "E1002");
-        assert_str!(do_lisp("(integer->char -999)"), "E1019");
-        assert_str!(do_lisp("(integer->char a)"), "E1008");
+        assert_eq!(do_lisp("(integer->char)"), "E1007");
+        assert_eq!(do_lisp("(integer->char 23 665)"), "E1007");
+        assert_eq!(do_lisp("(integer->char #\\a)"), "E1002");
+        assert_eq!(do_lisp("(integer->char -999)"), "E1019");
+        assert_eq!(do_lisp("(integer->char a)"), "E1008");
     }
     #[test]
     fn char_integer() {
-        assert_str!(do_lisp("(char->integer)"), "E1007");
-        assert_str!(do_lisp("(char->integer #\\a #\\b)"), "E1007");
-        assert_str!(do_lisp("(char->integer 999)"), "E1019");
-        assert_str!(do_lisp("(char->integer a)"), "E1008");
+        assert_eq!(do_lisp("(char->integer)"), "E1007");
+        assert_eq!(do_lisp("(char->integer #\\a #\\b)"), "E1007");
+        assert_eq!(do_lisp("(char->integer 999)"), "E1019");
+        assert_eq!(do_lisp("(char->integer a)"), "E1008");
     }
     #[test]
     fn quote() {
-        assert_str!(do_lisp("(quote)"), "E1007");
-        assert_str!(do_lisp("(quote 1 2)"), "E1007");
+        assert_eq!(do_lisp("(quote)"), "E1007");
+        assert_eq!(do_lisp("(quote 1 2)"), "E1007");
     }
     #[test]
     fn get_env() {
-        assert_str!(do_lisp("(get-environment-variable)"), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp("(get-environment-variable)"), "E1007");
+        assert_eq!(
             do_lisp("(get-environment-variable  \"HOME\"  \"HOME\")"),
             "E1007"
         );
-        assert_str!(do_lisp("(get-environment-variable a)"), "E1008");
-        assert_str!(do_lisp("(get-environment-variable #t)"), "E1015");
+        assert_eq!(do_lisp("(get-environment-variable a)"), "E1008");
+        assert_eq!(do_lisp("(get-environment-variable #t)"), "E1015");
     }
 }

--- a/elisp/tests/integration_test.rs
+++ b/elisp/tests/integration_test.rs
@@ -10,12 +10,6 @@
 extern crate elisp;
 use elisp::lisp;
 
-macro_rules! assert_str {
-    ($a: expr,
-     $b: expr) => {
-        assert!($a == $b.to_string())
-    };
-}
 fn do_lisp_env(program: &str, env: &lisp::Environment) -> String {
     match lisp::do_core_logic(&program.into(), env) {
         Ok(v) => v.to_string(),
@@ -32,10 +26,10 @@ fn leap() {
          (= 0 (modulo year 400))))",
         &env,
     );
-    assert_str!(do_lisp_env("(leap? 1900)", &env), "#f");
-    assert_str!(do_lisp_env("(leap? 1996)", &env), "#t");
-    assert_str!(do_lisp_env("(leap? 1997)", &env), "#f");
-    assert_str!(do_lisp_env("(leap? 2000)", &env), "#t");
+    assert_eq!(do_lisp_env("(leap? 1900)", &env), "#f");
+    assert_eq!(do_lisp_env("(leap? 1996)", &env), "#t");
+    assert_eq!(do_lisp_env("(leap? 1997)", &env), "#f");
+    assert_eq!(do_lisp_env("(leap? 2000)", &env), "#t");
 }
 #[test]
 fn gcm() {
@@ -49,10 +43,10 @@ fn gcm() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(gcm 36 27)", &env), "9");
-    assert_str!(do_lisp_env("(effect/gcm 36 15)", &env), "3");
-    assert_str!(do_lisp_env("(lcm 36 27)", &env), "108");
-    assert_str!(do_lisp_env("(bad-gcm 36 27)", &env), "9");
+    assert_eq!(do_lisp_env("(gcm 36 27)", &env), "9");
+    assert_eq!(do_lisp_env("(effect/gcm 36 15)", &env), "3");
+    assert_eq!(do_lisp_env("(lcm 36 27)", &env), "108");
+    assert_eq!(do_lisp_env("(bad-gcm 36 27)", &env), "9");
 }
 #[test]
 fn fact() {
@@ -65,8 +59,8 @@ fn fact() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(fact 5)", &env), "120");
-    assert_str!(do_lisp_env("(fact-iter 4 1)", &env), "24");
+    assert_eq!(do_lisp_env("(fact 5)", &env), "120");
+    assert_eq!(do_lisp_env("(fact-iter 4 1)", &env), "24");
 }
 #[test]
 fn hanoi() {
@@ -78,11 +72,11 @@ fn hanoi() {
          (list (list (cons from to) n)) (hanoi work to from (- n 1))))))",
         &env,
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(hanoi (quote a)(quote b)(quote c) 3)", &env),
         "(((a . b) 1)((a . c) 2)((b . c) 1)((a . b) 3)((c . a) 1)((c . b) 2)((a . b) 1))"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(hanoi 'a 'b 'c 3)", &env),
         "(((a . b) 1)((a . c) 2)((b . c) 1)((a . b) 3)((c . a) 1)((c . b) 2)((a . b) 1))"
     );
@@ -96,7 +90,7 @@ fn prime() {
          (cons (car l)(prime (filter (lambda (n) (not (= 0 (modulo n (car l))))) (cdr l))))))",
         &env,
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(prime (iota 30 2))", &env),
         "(2 3 5 7 11 13 17 19 23 29 31)"
     );
@@ -114,12 +108,12 @@ fn perm() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(perm-count 3 2)", &env), "6");
-    assert_str!(
+    assert_eq!(do_lisp_env("(perm-count 3 2)", &env), "6");
+    assert_eq!(
         do_lisp_env("(perm (list 1 2 3) 2)", &env),
         "((1 2)(1 3)(2 1)(2 3)(3 1)(3 2))"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(perm '(a b c) 2)", &env),
         "((a b)(a c)(b a)(b c)(c a)(c b))"
     );
@@ -138,12 +132,12 @@ fn comb() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(comb-count 3 2)", &env), "3");
-    assert_str!(
+    assert_eq!(do_lisp_env("(comb-count 3 2)", &env), "3");
+    assert_eq!(
         do_lisp_env("(comb (list 1 2 3) 2)", &env),
         "((1 2)(1 3)(2 3))"
     );
-    assert_str!(do_lisp_env("(comb '(a b c) 2)", &env), "((a b)(a c)(b c))");
+    assert_eq!(do_lisp_env("(comb '(a b c) 2)", &env), "((a b)(a c)(b c))");
 }
 #[test]
 fn quick_sort() {
@@ -157,11 +151,11 @@ fn quick_sort() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(qsort test-list (lambda (a b)(< a b)))", &env),
         "(0 2 3 6 7 8 9 14 19 27 36)"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(qsort test-list (lambda (a b)(> a b)))", &env),
         "(36 27 19 14 9 8 7 6 3 2 0)"
     );
@@ -178,7 +172,7 @@ fn bubble_sort() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(bsort test-list)", &env),
         "(0 2 3 6 7 8 9 14 19 27 36)"
     );
@@ -199,11 +193,11 @@ fn merge_sort() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(merge (list 1 3 5 7 9)(list 2 4 6 8 10))", &env),
         "(1 2 3 4 5 6 7 8 9 10)"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(msort test-list)", &env),
         "(0 2 3 6 7 8 9 14 19 27 36)"
     );
@@ -222,14 +216,14 @@ fn inf_list() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(
+    assert_eq!(
         do_lisp_env(
             "(inf-list (lambda (n) (list (+ 1 (car n)))) (list 0) 10)",
             &env
         ),
         "(0 1 2 3 4 5 6 7 8 9)"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env(
             "(inf-list (lambda (n) (list (cadr n)(+ (cadr n) (car n)))) (list 0 1) 10)",
             &env
@@ -251,19 +245,19 @@ fn cps() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(fact-cps 4 (lambda (a) a))", &env), "24");
-    assert_str!(do_lisp_env("(fact-cps 4 (lambda (a) (* 2 a)))", &env), "48");
-    assert_str!(do_lisp_env("(fact/cps 5 (lambda (a) a))", &env), "120");
-    assert_str!(
+    assert_eq!(do_lisp_env("(fact-cps 4 (lambda (a) a))", &env), "24");
+    assert_eq!(do_lisp_env("(fact-cps 4 (lambda (a) (* 2 a)))", &env), "48");
+    assert_eq!(do_lisp_env("(fact/cps 5 (lambda (a) a))", &env), "120");
+    assert_eq!(
         do_lisp_env("(fact/cps 5 (lambda (a) (* 2 a)))", &env),
         "240"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(fact/cps-ng 3 (lambda (a) (* 2 a)))", &env),
         "E1007"
     );
-    assert_str!(do_lisp_env("(fact/cps 5 (lambda (a b) a))", &env), "E1007");
-    assert_str!(
+    assert_eq!(do_lisp_env("(fact/cps 5 (lambda (a b) a))", &env), "E1007");
+    assert_eq!(
         do_lisp_env("(fact/cps 5 (lambda (a) (+ ng a)))", &env),
         "E1008"
     );
@@ -283,8 +277,8 @@ fn closure() {
     for _i in 0..5 {
         do_lisp_env("(b)", &env);
     }
-    assert_str!(do_lisp_env("(a)", &env), "11");
-    assert_str!(do_lisp_env("(b)", &env), "6");
+    assert_eq!(do_lisp_env("(a)", &env), "11");
+    assert_eq!(do_lisp_env("(b)", &env), "6");
 
     do_lisp_env(
         "(define (scounter step) (let ((c 0)) (lambda () (set! c (+ step c)) c)))",
@@ -296,8 +290,8 @@ fn closure() {
         do_lisp_env("(x)", &env);
         do_lisp_env("(y)", &env);
     }
-    assert_str!(do_lisp_env("(x)", &env), "30");
-    assert_str!(do_lisp_env("(y)", &env), "300");
+    assert_eq!(do_lisp_env("(x)", &env), "30");
+    assert_eq!(do_lisp_env("(y)", &env), "300");
 }
 #[test]
 fn closure_nest() {
@@ -305,7 +299,7 @@ fn closure_nest() {
 
     do_lisp_env("(define (testf x) (lambda () (* x 10)))", &env);
     do_lisp_env("(define (foo x) (testf (* 2 x)))", &env);
-    assert_str!(do_lisp_env("((foo 2))", &env), "40");
+    assert_eq!(do_lisp_env("((foo 2))", &env), "40");
 
     do_lisp_env(
         "(define (counter x) (let ((c 0)) (lambda () (set! c (+ x c)) c)))",
@@ -313,8 +307,8 @@ fn closure_nest() {
     );
     do_lisp_env("(define (make-counter c) (counter c))", &env);
     do_lisp_env("(define c (make-counter 10))", &env);
-    assert_str!(do_lisp_env("(c)", &env), "10");
-    assert_str!(do_lisp_env("(c)", &env), "20");
+    assert_eq!(do_lisp_env("(c)", &env), "10");
+    assert_eq!(do_lisp_env("(c)", &env), "20");
 }
 #[test]
 fn fibonacci() {
@@ -327,7 +321,7 @@ fn fibonacci() {
          (fibonacci (- n 2))))))",
         &env,
     );
-    assert_str!(do_lisp_env("(fibonacci 8)", &env), "21");
+    assert_eq!(do_lisp_env("(fibonacci 8)", &env), "21");
 }
 #[test]
 fn trigonometric() {
@@ -348,16 +342,16 @@ fn trigonometric() {
     for p in &program {
         do_lisp_env(p, &env);
     }
-    assert_str!(do_lisp_env("(x-dash 1.0 0 60)", &env), "0.5000000000000001");
-    assert_str!(
+    assert_eq!(do_lisp_env("(x-dash 1.0 0 60)", &env), "0.5000000000000001");
+    assert_eq!(
         do_lisp_env("(y-dash 1.0 0 30)", &env),
         "0.49999999999999994"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(get-angle 0 0.5 0 0.8660254037844387)", &env),
         "60.00000000000001"
     );
-    assert_str!(
+    assert_eq!(
         do_lisp_env("(get-angle2 0 0.5 0 0.8660254037844387)", &env),
         "60.00000000000001"
     );

--- a/glisp/src/lib.rs
+++ b/glisp/src/lib.rs
@@ -23,12 +23,6 @@ mod tests {
     use std::io::Write;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    macro_rules! assert_str {
-        ($a: expr,
-         $b: expr) => {
-            assert!($a == $b.to_string())
-        };
-    }
     fn do_lisp_env(program: &str, env: &Environment) -> String {
         match lisp::do_core_logic(&program.into(), env) {
             Ok(v) => v.to_string(),
@@ -67,72 +61,72 @@ mod tests {
     fn test_01_normal_check() {
         let env = init();
         // draw-clear check
-        assert_str!(do_lisp_env("(draw-clear)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-line 0.0 1.0 0.2 0.3)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-koch 2)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-tree 2)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-sierpinski 2)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-dragon 2)", &env), "nil");
-        assert_str!(do_lisp_env("(draw-hilvert 2)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-clear)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-line 0.0 1.0 0.2 0.3)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-koch 2)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-tree 2)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-sierpinski 2)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-dragon 2)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-hilvert 2)", &env), "nil");
 
-        assert_str!(do_lisp_env("(set-background 0.0 0.0 0.0)", &env), "nil");
-        assert_str!(do_lisp_env("(set-foreground 0.0 1.0 0.0)", &env), "nil");
-        assert_str!(do_lisp_env("(set-line-width 0.001)", &env), "nil");
-        assert_str!(
+        assert_eq!(do_lisp_env("(set-background 0.0 0.0 0.0)", &env), "nil");
+        assert_eq!(do_lisp_env("(set-foreground 0.0 1.0 0.0)", &env), "nil");
+        assert_eq!(do_lisp_env("(set-line-width 0.001)", &env), "nil");
+        assert_eq!(
             do_lisp_env("(draw-string 0.04 0.50 0.15 \"日本語\")", &env),
             "nil"
         );
-        assert_str!(do_lisp_env("(draw-arc 0.27 0.65 0.02 0.0)", &env), "nil");
+        assert_eq!(do_lisp_env("(draw-arc 0.27 0.65 0.02 0.0)", &env), "nil");
 
         let png = create_png_file("1");
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 format!("(create-image-from-png \"sample\" \"{}\")", png).as_str(),
                 &env,
             ),
             "nil"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-image \"sample\" 0.0 0.0 1.0 0.0 0.0 1.0)", &env),
             "nil"
         );
-        assert_str!(do_lisp_env("(image-width \"sample\")", &env), "1");
-        assert_str!(do_lisp_env("(image-height \"sample\")", &env), "1");
+        assert_eq!(do_lisp_env("(image-width \"sample\")", &env), "1");
+        assert_eq!(do_lisp_env("(image-height \"sample\")", &env), "1");
         std::fs::remove_file(png).unwrap();
 
-        assert_str!(do_lisp_env("(get-screen-width)", &env), "720");
-        assert_str!(do_lisp_env("(get-screen-height)", &env), "560");
-        assert_str!(do_lisp_env("(draw-eval (iota 10))", &env), "nil");
+        assert_eq!(do_lisp_env("(get-screen-width)", &env), "720");
+        assert_eq!(do_lisp_env("(get-screen-height)", &env), "560");
+        assert_eq!(do_lisp_env("(draw-eval (iota 10))", &env), "nil");
     }
     #[test]
     fn test_02_error_check() {
         let env = init();
         // draw-clear check
-        assert_str!(do_lisp_env("(draw-clear 10)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-clear 10)", &env), "E1007");
     }
     #[test]
     fn test_03_error_check() {
         let env = init();
         // draw-line check
-        assert_str!(do_lisp_env("(draw-line)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-line 0.0 1.0 2.0 3)", &env), "E1003");
-        assert_str!(do_lisp_env("(draw-line a b 2.0 3)", &env), "E1008");
-        assert_str!(do_lisp_env("(draw-line 0.0 1.0 2.0 3)", &env), "E1003");
-        assert_str!(do_lisp_env("(draw-line a b 2.0 3)", &env), "E1008");
+        assert_eq!(do_lisp_env("(draw-line)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-line 0.0 1.0 2.0 3)", &env), "E1003");
+        assert_eq!(do_lisp_env("(draw-line a b 2.0 3)", &env), "E1008");
+        assert_eq!(do_lisp_env("(draw-line 0.0 1.0 2.0 3)", &env), "E1003");
+        assert_eq!(do_lisp_env("(draw-line a b 2.0 3)", &env), "E1008");
     }
     #[test]
     fn test_04_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-string)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(draw-string)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(draw-string 0.04 0.50 0.15 \"日本語\" 0.04)", &env),
             "E1007"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-string 0.04 0.50 \"日本語\" 0.04)", &env),
             "E1003"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-string 0.04 0.50  0.15 0.01)", &env),
             "E1015"
         );
@@ -140,12 +134,12 @@ mod tests {
     #[test]
     fn test_05_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-arc)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(draw-arc)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(draw-arc 0.27 0.65 0.02 0.0 1.0)", &env),
             "E1007"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-arc 0.04 0.50 \"日本語\" 0.04)", &env),
             "E1003"
         );
@@ -153,26 +147,26 @@ mod tests {
     #[test]
     fn test_06_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(set-background)", &env), "E1007");
-        assert_str!(do_lisp_env("(set-background 1.0)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(set-background)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set-background 1.0)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(set-background 0.0 1.0 2.0 1.0)", &env),
             "E1007"
         );
-        assert_str!(do_lisp_env("(set-background 0.0 1.0 2)", &env), "E1003");
-        assert_str!(do_lisp_env("(set-background 0.0 1.0 a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(set-background 0.0 1.0 2)", &env), "E1003");
+        assert_eq!(do_lisp_env("(set-background 0.0 1.0 a)", &env), "E1008");
     }
     #[test]
     fn test_07_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(set-foreground)", &env), "E1007");
-        assert_str!(do_lisp_env("(set-foreground 1.0)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(set-foreground)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set-foreground 1.0)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(set-foreground 0.0 1.0 2.0 1.0)", &env),
             "E1007"
         );
-        assert_str!(do_lisp_env("(set-foreground 0.0 1.0 2)", &env), "E1003");
-        assert_str!(do_lisp_env("(set-foreground 0.0 1.0 a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(set-foreground 0.0 1.0 2)", &env), "E1003");
+        assert_eq!(do_lisp_env("(set-foreground 0.0 1.0 a)", &env), "E1008");
     }
     #[test]
     fn test_08_error_check() {
@@ -185,20 +179,20 @@ mod tests {
                 .as_secs()
         );
         // create-image-from-png check
-        assert_str!(do_lisp_env("(create-image-from-png)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(create-image-from-png)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(create-image-from-png \"sample\")", &env),
             "E1007"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(create-image-from-png 10 \"/tmp/hoge.png\")", &env),
             "E1015"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(create-image-from-png \"sample\" 20)", &env),
             "E1015"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 format!("(create-image-from-png \"sample\" \"{}\")", png).as_str(),
                 &env
@@ -206,7 +200,7 @@ mod tests {
             "E9999"
         );
         File::create(&png).unwrap();
-        assert_str!(
+        assert_eq!(
             do_lisp_env(
                 format!("(create-image-from-png \"sample\" \"{}\")", png).as_str(),
                 &env
@@ -219,99 +213,99 @@ mod tests {
             &env,
         );
 
-        assert_str!(do_lisp_env("(draw-image)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-image 10)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(draw-image)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-image 10)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(draw-image \"sample\" 1 2 3 10)", &env),
             "E1007"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-image 10 0.0 0.0 1.0 0.0 0.0 1.0)", &env),
             "E1015"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-image \"sample1\" 0.0 0.0 1.0 0.0 0.0 1.0)", &env),
             "E1008"
         );
-        assert_str!(
+        assert_eq!(
             do_lisp_env("(draw-image \"sample\" 0.0 0.0 1.0 1.0 1.0 10)", &env),
             "E1003"
         );
-        assert_str!(do_lisp_env("(image-width)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(image-width)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(image-width \"sample\" \"sample1\")", &env),
             "E1007"
         );
-        assert_str!(do_lisp_env("(image-width 10)", &env), "E1015");
-        assert_str!(do_lisp_env("(image-width a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(image-width 10)", &env), "E1015");
+        assert_eq!(do_lisp_env("(image-width a)", &env), "E1008");
 
-        assert_str!(do_lisp_env("(image-height)", &env), "E1007");
-        assert_str!(
+        assert_eq!(do_lisp_env("(image-height)", &env), "E1007");
+        assert_eq!(
             do_lisp_env("(image-height \"sample\" \"sample1\")", &env),
             "E1007"
         );
-        assert_str!(do_lisp_env("(image-height 10)", &env), "E1015");
-        assert_str!(do_lisp_env("(image-height a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(image-height 10)", &env), "E1015");
+        assert_eq!(do_lisp_env("(image-height a)", &env), "E1008");
         std::fs::remove_file(png).unwrap();
     }
     #[test]
     fn test_09_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-koch)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-koch 10 20)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-koch 10.5)", &env), "E1002");
+        assert_eq!(do_lisp_env("(draw-koch)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-koch 10 20)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-koch 10.5)", &env), "E1002");
     }
     #[test]
     fn test_10_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-tree)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-tree 10 20)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-tree 10.5)", &env), "E1002");
+        assert_eq!(do_lisp_env("(draw-tree)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-tree 10 20)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-tree 10.5)", &env), "E1002");
     }
     #[test]
     fn test_11_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-sierpinski)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-sierpinski 10 20)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-sierpinski 10.5)", &env), "E1002");
+        assert_eq!(do_lisp_env("(draw-sierpinski)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-sierpinski 10 20)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-sierpinski 10.5)", &env), "E1002");
     }
     #[test]
     fn test_12_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-dragon)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-dragon 10 20)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-dragon 10.5)", &env), "E1002");
+        assert_eq!(do_lisp_env("(draw-dragon)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-dragon 10 20)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-dragon 10.5)", &env), "E1002");
     }
     #[test]
     fn test_13_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-hilvert)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-hilvert 10 20)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-hilvert 10.5)", &env), "E1002");
+        assert_eq!(do_lisp_env("(draw-hilvert)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-hilvert 10 20)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-hilvert 10.5)", &env), "E1002");
     }
     #[test]
     fn test_14_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(set-line-width)", &env), "E1007");
-        assert_str!(do_lisp_env("(set-line-width  0.001 0.001)", &env), "E1007");
-        assert_str!(do_lisp_env("(set-line-width 2)", &env), "E1003");
-        assert_str!(do_lisp_env("(set-line-width a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(set-line-width)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set-line-width  0.001 0.001)", &env), "E1007");
+        assert_eq!(do_lisp_env("(set-line-width 2)", &env), "E1003");
+        assert_eq!(do_lisp_env("(set-line-width a)", &env), "E1008");
     }
     #[test]
     fn test_15_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(get-screen-width a)", &env), "E1007");
+        assert_eq!(do_lisp_env("(get-screen-width a)", &env), "E1007");
     }
     #[test]
     fn test_16_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(get-screen-height b)", &env), "E1007");
+        assert_eq!(do_lisp_env("(get-screen-height b)", &env), "E1007");
     }
     #[test]
     fn test_17_error_check() {
         let env = init();
-        assert_str!(do_lisp_env("(draw-eval)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-eval a b)", &env), "E1007");
-        assert_str!(do_lisp_env("(draw-eval a)", &env), "E1008");
+        assert_eq!(do_lisp_env("(draw-eval)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-eval a b)", &env), "E1007");
+        assert_eq!(do_lisp_env("(draw-eval a)", &env), "E1008");
     }
 }


### PR DESCRIPTION
独自のassert_strを廃止し、標準のassert_eqに変更する