### PR TITLE
glispのexampleのコンパイルエラー対応

### DIFF
--- a/glisp/examples/load_image_url.rs
+++ b/glisp/examples/load_image_url.rs
@@ -9,105 +9,108 @@
             (/ (image-width "rb") (screen-width) 1.0) 0.0
             0.0 (/ (image-height "rb")(screen-height) 1.0))
 
+    (define ll (paint-image "ll"))
+    (define aframe (make-image-frame "ll" 2.0))
+    ((square-limit ll 0) aframe)
+
    hidekuno@gmail.com
 */
 extern crate elisp;
 extern crate glisp;
 extern crate surf;
-extern crate gio;
-extern crate glib;
 
 use std::rc::Rc;
 
-use glib::Bytes;
-use gio::MemoryInputStream;
-use gdk_pixbuf::Pixbuf;
-use surf::http::StatusCode;
 use async_std::task;
+use gtk::gdk_pixbuf::Pixbuf;
+use gtk::gio::Cancellable;
+use gtk::gio::MemoryInputStream;
+use gtk::glib::Bytes;
+
+use surf::http::StatusCode;
 
 use crate::elisp::create_error;
-use elisp::lisp;
-use glisp::buildin;
-use glisp::draw;
-use glisp::ui;
-use lisp::Environment;
-use lisp::ErrCode;
-use lisp::Expression;
-use lisp::Error;
-use lisp::eval;
 use buildin::build_demo_function;
 use buildin::build_lisp_function;
 use draw::create_draw_table;
 use draw::DrawTable;
 use draw::PixbufWrapper;
+use elisp::lisp;
+use glisp::buildin;
+use glisp::draw;
+use glisp::ui;
+use lisp::eval;
+use lisp::Environment;
+use lisp::ErrCode;
+use lisp::Error;
+use lisp::Expression;
 use ui::scheme_gtk;
 
 #[cfg(not(feature = "redirect"))]
-fn load_url(url: &String) -> Result<(Vec<u8>,StatusCode),
-                                    Box<dyn std::error::Error + Send + Sync + 'static>> {
-    task::block_on(
-        async {
-            let mut res = surf::get(url).await?;
-            let body = res.body_bytes().await?;
-            Ok((body, res.status()))
-        }
-    )
+fn load_url(
+    url: &String,
+) -> Result<(Vec<u8>, StatusCode), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    task::block_on(async {
+        let mut res = surf::get(url).await?;
+        let body = res.body_bytes().await?;
+        Ok((body, res.status()))
+    })
 }
 #[cfg(feature = "redirect")]
-fn load_url(url: &str) -> Result<(Vec<u8>,StatusCode),
-                                    Box<dyn std::error::Error + Send + Sync + 'static>> {
-    task::block_on(
-        async {
-            let req = surf::get(url);
-            let client = surf::client().with(surf::middleware::Redirect::new(5));
-            let mut res = client.send(req).await?;
-            let body = res.body_bytes().await?;
-            Ok((body, res.status()))
-        }
-    )
+fn load_url(
+    url: &str,
+) -> Result<(Vec<u8>, StatusCode), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    task::block_on(async {
+        let req = surf::get(url);
+        let client = surf::client().with(surf::middleware::Redirect::new(5));
+        let mut res = client.send(req).await?;
+        let body = res.body_bytes().await?;
+        Ok((body, res.status()))
+    })
 }
 fn build_example_function(app: &Application) {
     let draw_table = app.draw_table.clone();
-    app.env.add_builtin_ext_func("load-image-url", move |exp, env| {
-        if exp.len() != 3 {
-            return Err(create_error!(ErrCode::E1007));
-        }
-        let symbol = match lisp::eval(&exp[1], env)? {
-            Expression::String(s) => s,
-            _ => return Err(create_error!(ErrCode::E1015)),
-        };
+    app.env
+        .add_builtin_ext_func("load-image-url", move |exp, env| {
+            if exp.len() != 3 {
+                return Err(create_error!(ErrCode::E1007));
+            }
+            let symbol = match lisp::eval(&exp[1], env)? {
+                Expression::String(s) => s,
+                _ => return Err(create_error!(ErrCode::E1015)),
+            };
 
-        let url = if let Expression::String(s) = eval(&exp[2],env)? {
-            s
-        } else {
-            return Err(create_error!(ErrCode::E1015));
-        };
-        if !url.starts_with("http://")  && !url.starts_with("https://") {
-            return Err(create_error!(ErrCode::E1021));
-        }
+            let url = if let Expression::String(s) = eval(&exp[2], env)? {
+                s
+            } else {
+                return Err(create_error!(ErrCode::E1015));
+            };
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                return Err(create_error!(ErrCode::E1021));
+            }
 
-        let img = match load_url(&url) {
-            Err(e) => {
-                println!("{:?}", e);
-                return Err(create_error!(ErrCode::E9999));
-            },
-            Ok(s) => {
-                if s.1 != 200 {
-                    println!("{}", s.1);
+            let img = match load_url(&url) {
+                Err(e) => {
+                    println!("{:?}", e);
                     return Err(create_error!(ErrCode::E9999));
                 }
-                s.0
-            }
-        };
-        let b = Bytes::from_owned(img);
-        let stream = MemoryInputStream::from_bytes(&b);
-        let pix = match Pixbuf::from_stream(&stream, None::<&gio::Cancellable>) {
-            Ok(pix) => pix,
-            Err(_) => return Err(create_error!(ErrCode::E9999)),
-        };
-        draw_table.regist(symbol, Rc::new(PixbufWrapper::new(pix)));
-        Ok(Expression::Nil())
-    });
+                Ok(s) => {
+                    if s.1 != 200 {
+                        println!("{}", s.1);
+                        return Err(create_error!(ErrCode::E9999));
+                    }
+                    s.0
+                }
+            };
+            let b = Bytes::from_owned(img);
+            let stream = MemoryInputStream::from_bytes(&b);
+            let pix = match Pixbuf::from_stream(&stream, None::<&Cancellable>) {
+                Ok(pix) => pix,
+                Err(_) => return Err(create_error!(ErrCode::E9999)),
+            };
+            draw_table.regist(symbol, Rc::new(PixbufWrapper::new(pix)));
+            Ok(Expression::Nil())
+        });
 }
 struct Application<'a> {
     env: &'a Environment,
@@ -115,10 +118,7 @@ struct Application<'a> {
 }
 impl<'a> Application<'a> {
     fn new(env: &'a Environment, draw_table: &'a DrawTable) -> Self {
-        Application {
-            env,
-            draw_table,
-        }
+        Application { env, draw_table }
     }
 }
 fn create_app<'a>(env: &'a Environment, draw_table: &'a DrawTable) -> Application<'a> {


### PR DESCRIPTION
glispのexampleのコンパイルエラー対応
```
cargo clippy  --all-targets --all-features -- -D warnings
```