### PR TITLE
listの文字列の書式を修正した

### DIFF
--- a/elisp/src/lisp.rs
+++ b/elisp/src/lisp.rs
@@ -775,7 +775,7 @@ impl TokenState {
         self.tokens
     }
 }
-pub fn tokenize(program: &str) -> Vec<String> {
+pub(crate) fn tokenize(program: &str) -> Vec<String> {
     let mut token = TokenState::new();
     let mut from = 0;
     let mut vector_mode = false;
@@ -867,7 +867,7 @@ pub fn tokenize(program: &str) -> Vec<String> {
     debug!("{:?}", token.tokens);
     token.tokens()
 }
-pub fn parse(tokens: &[String], count: &mut i32, env: &Environment) -> ResultExpression {
+pub(crate) fn parse(tokens: &[String], count: &mut i32, env: &Environment) -> ResultExpression {
     if tokens.is_empty() {
         return Err(create_error!(ErrCode::E0001));
     }

--- a/elisp/src/lisp.rs
+++ b/elisp/src/lisp.rs
@@ -303,9 +303,7 @@ impl Expression {
     fn list_string(exp: &[Expression]) -> String {
         let mut s = String::from("(");
 
-        let mut c = 1;
-        let mut el = false;
-        for e in exp {
+        for (c, e) in exp.iter().enumerate() {
             match e {
                 Expression::List(l) | Expression::Vector(l) => {
                     if let Expression::Vector(_) = e {
@@ -313,20 +311,14 @@ impl Expression {
                     }
                     let l = &*(referlence_list!(l));
                     s.push_str(Expression::list_string(&l[..]).as_str());
-                    el = true;
                 }
                 _ => {
-                    if el {
-                        s.push(' ');
-                    }
                     s.push_str(e.to_string().as_str());
-                    if c != exp.len() {
-                        s.push(' ');
-                    }
-                    el = false;
                 }
             }
-            c += 1;
+            if c != exp.len() - 1 {
+                s.push(' ');
+            }
         }
         s.push(')');
         s

--- a/elisp/src/list.rs
+++ b/elisp/src/list.rs
@@ -933,10 +933,10 @@ mod tests {
         assert_eq!(do_lisp("(list 1 2)"), "(1 2)");
         assert_eq!(do_lisp("(list 0.5 1)"), "(0.5 1)");
         assert_eq!(do_lisp("(list #t #f)"), "(#t #f)");
-        assert_eq!(do_lisp("(list (list 1)(list 2))"), "((1)(2))");
+        assert_eq!(do_lisp("(list (list 1)(list 2))"), "((1) (2))");
         assert_eq!(
             do_lisp("(list (list (list 1))(list 2)(list 3))"),
-            "(((1))(2)(3))"
+            "(((1)) (2) (3))"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a 10)", &env);
@@ -948,7 +948,7 @@ mod tests {
         assert_eq!(do_lisp("(make-list 10 0)"), "(0 0 0 0 0 0 0 0 0 0)");
         assert_eq!(
             do_lisp("(make-list 4 (list 1 2 3))"),
-            "((1 2 3)(1 2 3)(1 2 3)(1 2 3))"
+            "((1 2 3) (1 2 3) (1 2 3) (1 2 3))"
         );
         assert_eq!(do_lisp("(make-list 8 'a)"), "(a a a a a a a a)");
         assert_eq!(do_lisp("(make-list 0 'a)"), "()");
@@ -1141,7 +1141,7 @@ mod tests {
             do_lisp("(map (lambda (n) (* n 10)) (iota 10 1))"),
             "(10 20 30 40 50 60 70 80 90 100)"
         );
-        assert_eq!(do_lisp("(map list (list 1 2 3))"), "((1)(2)(3))");
+        assert_eq!(do_lisp("(map list (list 1 2 3))"), "((1) (2) (3))");
         assert_eq!(do_lisp("(map (lambda (n) (car n)) (list))"), "()");
         assert_eq!(
             do_lisp("(map car (list (list 1 2 3)(list 4 5 6) (list 7 8 9)))"),
@@ -1169,11 +1169,11 @@ mod tests {
                 "(map (lambda (n)(map (lambda (m)(/ m 10)) n))(list (list 10 20 30)(list a b c)))",
                 &env
             ),
-            "((1 2 3)(10 20 30))"
+            "((1 2 3) (10 20 30))"
         );
         assert_eq!(
             do_lisp_env("(map (lambda (n) (car n)) d)", &env),
-            "((1)(2)(3))"
+            "((1) (2) (3))"
         );
     }
     #[test]
@@ -1616,10 +1616,10 @@ mod tests {
         assert_eq!(do_lisp("(vector 1 2)"), "#(1 2)");
         assert_eq!(do_lisp("(vector 0.5 1)"), "#(0.5 1)");
         assert_eq!(do_lisp("(vector #t #f)"), "#(#t #f)");
-        assert_eq!(do_lisp("(vector (list 1)(list 2))"), "#((1)(2))");
+        assert_eq!(do_lisp("(vector (list 1)(list 2))"), "#((1) (2))");
         assert_eq!(
             do_lisp("(vector (vector (vector 1))(vector 2)(vector 3))"),
-            "#(#(#(1))#(2)#(3))"
+            "#(#(#(1)) #(2) #(3))"
         );
         let env = lisp::Environment::new();
         do_lisp_env("(define a 10)", &env);
@@ -1631,7 +1631,7 @@ mod tests {
         assert_eq!(do_lisp("(make-vector 10 0)"), "#(0 0 0 0 0 0 0 0 0 0)");
         assert_eq!(
             do_lisp("(make-vector 4 (list 1 2 3))"),
-            "#((1 2 3)(1 2 3)(1 2 3)(1 2 3))"
+            "#((1 2 3) (1 2 3) (1 2 3) (1 2 3))"
         );
         assert_eq!(do_lisp("(make-vector 8 'a)"), "#(a a a a a a a a)");
         assert_eq!(do_lisp("(make-vector 0 'a)"), "#()");

--- a/elisp/tests/integration_test.rs
+++ b/elisp/tests/integration_test.rs
@@ -74,11 +74,11 @@ fn hanoi() {
     );
     assert_eq!(
         do_lisp_env("(hanoi (quote a)(quote b)(quote c) 3)", &env),
-        "(((a . b) 1)((a . c) 2)((b . c) 1)((a . b) 3)((c . a) 1)((c . b) 2)((a . b) 1))"
+        "(((a . b) 1) ((a . c) 2) ((b . c) 1) ((a . b) 3) ((c . a) 1) ((c . b) 2) ((a . b) 1))"
     );
     assert_eq!(
         do_lisp_env("(hanoi 'a 'b 'c 3)", &env),
-        "(((a . b) 1)((a . c) 2)((b . c) 1)((a . b) 3)((c . a) 1)((c . b) 2)((a . b) 1))"
+        "(((a . b) 1) ((a . c) 2) ((b . c) 1) ((a . b) 3) ((c . a) 1) ((c . b) 2) ((a . b) 1))"
     );
 }
 #[test]
@@ -111,11 +111,11 @@ fn perm() {
     assert_eq!(do_lisp_env("(perm-count 3 2)", &env), "6");
     assert_eq!(
         do_lisp_env("(perm (list 1 2 3) 2)", &env),
-        "((1 2)(1 3)(2 1)(2 3)(3 1)(3 2))"
+        "((1 2) (1 3) (2 1) (2 3) (3 1) (3 2))"
     );
     assert_eq!(
         do_lisp_env("(perm '(a b c) 2)", &env),
-        "((a b)(a c)(b a)(b c)(c a)(c b))"
+        "((a b) (a c) (b a) (b c) (c a) (c b))"
     );
 }
 #[test]
@@ -135,9 +135,12 @@ fn comb() {
     assert_eq!(do_lisp_env("(comb-count 3 2)", &env), "3");
     assert_eq!(
         do_lisp_env("(comb (list 1 2 3) 2)", &env),
-        "((1 2)(1 3)(2 3))"
+        "((1 2) (1 3) (2 3))"
     );
-    assert_eq!(do_lisp_env("(comb '(a b c) 2)", &env), "((a b)(a c)(b c))");
+    assert_eq!(
+        do_lisp_env("(comb '(a b c) 2)", &env),
+        "((a b) (a c) (b c))"
+    );
 }
 #[test]
 fn quick_sort() {


### PR DESCRIPTION
listの文字列の書式を以下のように修正した

リストの要素がリストである場合、スペースが表示されない
```
rust.elisp> (map list (list 1 2 3))
((1)(2)(3))
rust.elisp>
```

goshでは要素の間にスペースが表示される
```
gosh> (map list (list 1 2 3))
((1) (2) (3))
gosh>
```
guileでも要素の間にスペースが表示される
```
scheme@(guile-user)> (map list (list 1 2 3))
$1 = ((1) (2) (3))
scheme@(guile-user)>
```