### PR TITLE
docker実行時のエラーに対応

### DIFF
--- a/docker/glisp/Dockerfile
+++ b/docker/glisp/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.57 as builder
+FROM rust:1.57-buster as builder
 MAINTAINER hidekuno@gmail.com
 
 ENV HOME /root
@@ -13,7 +13,7 @@ RUN cargo build --release --bin lisp && strip target/release/lisp
 WORKDIR $HOME/rust-elisp/glisp
 RUN cargo build --release --features animation --bin glisp && strip target/release/glisp
 
-FROM ubuntu:18.04 as glisp
+FROM debian:buster-slim as glisp
 MAINTAINER hidekuno@gmail.com
 
 RUN apt-get update && apt-get -y install libgtk-3-0


### PR DESCRIPTION
docker実行時のエラーに対応
```
$ docker run -e "DISPLAY=172.17.144.1:0.0" --name glisp hidekuno/rust-elisp /root/glisp
/root/glisp: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /root/glisp)
$
```